### PR TITLE
Transformer: frame resolve generalization

### DIFF
--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -546,7 +546,6 @@ namespace mrs_lib
     if (got_uav_name_)
     {
 
-      ROS_INFO_THROTTLE(1.0, "[%s]: Transformer debug: namespace: %s", ros::this_node::getName().c_str(), in.substr(0, uav_name_.length()).c_str());
       if (in.substr(0, uav_name_.length()) != uav_name_)
       {
 

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -543,10 +543,11 @@ namespace mrs_lib
       }
     }
 
-    if (in.substr(0, 3) != "uav")
+    if (got_uav_name_)
     {
 
-      if (got_uav_name_)
+      ROS_INFO_THROTTLE(1.0, "[%s]: Transformer debug: namespace: %s", ros::this_node::getName().c_str(), in.substr(0, uav_name_.length()).c_str());
+      if (in.substr(0, uav_name_.length()) != uav_name_)
       {
 
         return uav_name_ + "/" + in;
@@ -554,9 +555,13 @@ namespace mrs_lib
       } else
       {
 
-        ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: could not deduce a namespaced frame_id '%s' (did you instance the Transformer with the uav_name argument?)",
-                          node_name_.c_str(), in.c_str());
+        return in;
       }
+    } else
+    {
+
+      ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: could not deduce a namespaced frame_id '%s' (did you instance the Transformer with the uav_name argument?)",
+                        node_name_.c_str(), in.c_str());
     }
 
     return in;


### PR DESCRIPTION
Up to now the namespace of reference frames was required to start with "uav" (for example `uav1/fcu` for correct resolving of the frame id during transformation. However, in some cases (custom simulation environment, custom UAVs, using UGVs instead of UAVs, etc.) the namespace can start with something else.

This PR fixes this issue by generalizing the namespace to the `uav_name`, which is supplied during the construction of the `Transformer` object.