### PR TITLE
Possibility of deadlock in subscribe handler [DO NOT MERGE]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ target_link_libraries(param_loader_example
 add_executable(subscribe_handler_example src/subscribe_handler/example.cpp)
 target_link_libraries(subscribe_handler_example
   MrsLibTimer
+  MrsLibUtils
   ${catkin_LIBRARIES}
   ${Eigen_LIBRARIES}
   )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -424,6 +424,21 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_EXPORTED_TARGETS}
   )
 
+  add_rostest_gtest(
+    ServiceClientHandlerTest
+    test/service_client_handler/service_client_handler.test
+    test/service_client_handler/test.cpp
+  )
+  target_link_libraries(
+    ServiceClientHandlerTest
+    ${catkin_LIBRARIES}
+  )
+  add_dependencies(
+    ServiceClientHandlerTest
+    ${${PROJECT_NAME}_EXPORTED_TARGETS}
+    ${catkin_EXPORTED_TARGETS}
+  )
+
   # add_rostest_gtest(
   #   VectorConverterTest
   #   test/vector_converter/vector_converter.test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,12 @@ target_link_libraries(repredictor_example
   ${Eigen_LIBRARIES}
   )
 
+add_executable(service_client_handler_example src/service_client_handler/example.cpp)
+target_link_libraries(service_client_handler_example
+  ${catkin_LIBRARIES}
+  ${Eigen_LIBRARIES}
+  )
+
 add_library(MrsLibOdomLKF src/lkf/LKF_MRS_odom.cpp)
 target_link_libraries(MrsLibOdomLKF
   ${catkin_LIBRARIES}

--- a/include/impl/service_client_handler.hpp
+++ b/include/impl/service_client_handler.hpp
@@ -37,20 +37,6 @@ ServiceClientHandler_impl<ServiceType>::ServiceClientHandler_impl(ros::NodeHandl
 
 //}
 
-/* call(void) //{ */
-
-template <class ServiceType>
-bool ServiceClientHandler_impl<ServiceType>::call(void) {
-
-  if (!service_initialized_) {
-    return false;
-  }
-
-  return service_client_.call(async_data_);
-}
-
-//}
-
 /* call(ServiceType& srv) //{ */
 
 template <class ServiceType>
@@ -184,6 +170,16 @@ ServiceClientHandler<ServiceType>::ServiceClientHandler(const ServiceClientHandl
 
 template <class ServiceType>
 ServiceClientHandler<ServiceType>::ServiceClientHandler(ros::NodeHandle& nh, const std::string& address) {
+
+  impl_ = std::make_shared<ServiceClientHandler_impl<ServiceType>>(nh, address);
+}
+
+//}
+
+/* initialize(ros::NodeHandle& nh, const std::string& address) //{ */
+
+template <class ServiceType>
+void ServiceClientHandler<ServiceType>::initialize(ros::NodeHandle& nh, const std::string& address) {
 
   impl_ = std::make_shared<ServiceClientHandler_impl<ServiceType>>(nh, address);
 }

--- a/include/impl/service_client_handler.hpp
+++ b/include/impl/service_client_handler.hpp
@@ -122,8 +122,15 @@ std::future<ServiceType> ServiceClientHandler_impl<ServiceType>::callAsync(Servi
 template <class ServiceType>
 ServiceType ServiceClientHandler_impl<ServiceType>::asyncRun(void) {
 
-  auto async_data     = mrs_lib::get_mutexed(mutex_async_, async_data_);
-  auto async_attempts = mrs_lib::get_mutexed(mutex_async_, async_attempts_);
+  ServiceType async_data;
+  int         async_attempts;
+
+  {
+    std::scoped_lock lock(mutex_async_);
+
+    async_data     = async_data_;
+    async_attempts = async_attempts_;
+  }
 
   call(async_data, async_attempts);
 

--- a/include/impl/service_client_handler.hpp
+++ b/include/impl/service_client_handler.hpp
@@ -8,7 +8,7 @@ namespace mrs_lib
 // |                  ServiceClientHandler_impl                 |
 // --------------------------------------------------------------
 
-/* ServiceClientHandler_impl() //{ */
+/* ServiceClientHandler_impl(void) //{ */
 
 template <class ServiceType>
 ServiceClientHandler_impl<ServiceType>::ServiceClientHandler_impl(void) : service_initialized_(false) {
@@ -16,7 +16,7 @@ ServiceClientHandler_impl<ServiceType>::ServiceClientHandler_impl(void) : servic
 
 //}
 
-/* ServiceClientHandler_impl(ros::NodeHandle& nh, const std::string& address //{ */
+/* ServiceClientHandler_impl(ros::NodeHandle& nh, const std::string& address) //{ */
 
 template <class ServiceType>
 ServiceClientHandler_impl<ServiceType>::ServiceClientHandler_impl(ros::NodeHandle& nh, const std::string& address) {
@@ -37,7 +37,7 @@ ServiceClientHandler_impl<ServiceType>::ServiceClientHandler_impl(ros::NodeHandl
 
 //}
 
-/* call() //{ */
+/* call(void) //{ */
 
 template <class ServiceType>
 bool ServiceClientHandler_impl<ServiceType>::call(void) {
@@ -117,7 +117,7 @@ std::future<ServiceType> ServiceClientHandler_impl<ServiceType>::callAsync(Servi
 /* callAsync(ServiceType& srv, const int& attempts) //{ */
 
 template <class ServiceType>
-std::future<ServiceType> ServiceClientHandler_impl<ServiceType>::callAsync(ServiceType& srv, const int &attempts) {
+std::future<ServiceType> ServiceClientHandler_impl<ServiceType>::callAsync(ServiceType& srv, const int& attempts) {
 
   {
     std::scoped_lock lock(mutex_async_);
@@ -131,7 +131,7 @@ std::future<ServiceType> ServiceClientHandler_impl<ServiceType>::callAsync(Servi
 
 //}
 
-/* asyncRun(int i) //{ */
+/* asyncRun(void) //{ */
 
 template <class ServiceType>
 ServiceType ServiceClientHandler_impl<ServiceType>::asyncRun(void) {

--- a/include/impl/service_client_handler.hpp
+++ b/include/impl/service_client_handler.hpp
@@ -1,0 +1,9 @@
+#ifndef SERVICE_CLIENT_HANDLER_HPP
+#define SERVICE_CLIENT_HANDLER_HPP
+
+namespace mrs_lib
+{
+
+}  // namespace mrs_lib
+
+#endif  // SERVICE_CLIENT_HANDLER_HPP

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -1,3 +1,7 @@
+/**  \file
+     \brief Defines ServiceClientHandler and related convenience classes for upgrading the ROS service client
+     \author Tomas Baca - tomas.baca@fel.cvut.cz
+ */
 #ifndef SERVICE_CLIENT_HANDLER_H
 #define SERVICE_CLIENT_HANDLER_H
 

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -3,13 +3,11 @@
 
 #include <ros/ros.h>
 #include <ros/package.h>
+
 #include <string>
-#include <mutex>
 #include <future>
 
 #include <mrs_lib/mutex.h>
-
-#include <std_srvs/Trigger.h>
 
 namespace mrs_lib
 {
@@ -58,8 +56,8 @@ template <class ServiceType>
 class ServiceClientHandler {
 
 public:
-  ServiceClientHandler(){};
-  ~ServiceClientHandler(){};
+  ServiceClientHandler(void){};
+  ~ServiceClientHandler(void){};
 
   ServiceClientHandler& operator=(const ServiceClientHandler& other);
 

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -1,0 +1,69 @@
+#ifndef SERVICE_CLIENT_HANDLER_H
+#define SERVICE_CLIENT_HANDLER_H
+
+#include <ros/ros.h>
+#include <ros/package.h>
+#include <string>
+#include <mutex>
+
+#include <std_srvs/Trigger.h>
+
+namespace mrs_lib
+{
+
+template <class ServiceType>
+class ServiceClientHandler {
+
+public:
+  ServiceClientHandler() : service_initialized_(false) {
+  }
+
+  ~ServiceClientHandler() {};
+
+  ServiceClientHandler(ros::NodeHandle& nh, const std::string& topic_name) {
+
+    {
+      std::scoped_lock lock(mutex_service_client_);
+
+      service_client_ = std::make_shared<ros::ServiceClient>(nh.serviceClient<ServiceType>(topic_name));
+    }
+
+    service_initialized_ = true;
+  }
+
+  bool call(ServiceType& srv) {
+
+    return service_client_->call(srv);
+  }
+
+  ServiceClientHandler(const ServiceClientHandler& other) {
+
+    if (other.service_client_) {
+      this->service_client_ = other.service_client_;
+    }
+  }
+
+  ServiceClientHandler& operator=(const ServiceClientHandler& other) {
+
+    if (this == &other) {
+      return *this;
+    }
+
+    if (other.service_client_) {
+      this->service_client_ = other.service_client_;
+    }
+
+    return *this;
+  }
+
+private:
+  std::shared_ptr<ros::ServiceClient> service_client_;
+  std::mutex                          mutex_service_client_;
+  std::atomic<bool>                   service_initialized_;
+};
+
+}  // namespace mrs_lib
+
+#include <impl/service_client_handler.hpp>
+
+#endif  // SERVICE_CLIENT_HANDLER_H

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -10,8 +10,7 @@
 
 #include <string>
 #include <future>
-
-#include <mrs_lib/mutex.h>
+#include <mutex>
 
 namespace mrs_lib
 {

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -14,24 +14,67 @@ namespace mrs_lib
 
 /* class ServiceClientHandler_impl //{ */
 
+/**
+ * @brief implementation of the service client handler
+ */
 template <class ServiceType>
 class ServiceClientHandler_impl {
 
 public:
+  /**
+   * @brief default constructor
+   */
   ServiceClientHandler_impl(void);
 
+  /**
+   * @brief default destructor
+   */
   ~ServiceClientHandler_impl(void){};
 
+  /**
+   * @brief constructor
+   *
+   * @param nh ROS node handler
+   * @param address service address
+   */
   ServiceClientHandler_impl(ros::NodeHandle& nh, const std::string& address);
 
-  bool call(void);
-
+  /**
+   * @brief "classic" synchronous service call
+   *
+   * @param srv data
+   *
+   * @return true when success
+   */
   bool call(ServiceType& srv);
 
+  /**
+   * @brief "classic" synchronous service call with repeats after an error
+   *
+   * @param srv data
+   * @param attempts how many attempts for the call
+   *
+   * @return  true when success
+   */
   bool call(ServiceType& srv, const int& attempts);
 
+  /**
+   * @brief asynchronous service call
+   *
+   * @param srv data
+   *
+   * @return future result
+   */
   std::future<ServiceType> callAsync(ServiceType& srv);
 
+  /**
+   * @brief asynchronous service call with repeates after an error
+   *
+   * @param srv data
+   * @param attempts how many attempts for the call
+   *
+   * @return future result
+   */
   std::future<ServiceType> callAsync(ServiceType& srv, const int& attempts);
 
 private:
@@ -52,25 +95,91 @@ private:
 
 /* class ServiceClientHandler //{ */
 
+/**
+ * @brief user wrapper of the service client handler implementation
+ */
 template <class ServiceType>
 class ServiceClientHandler {
 
 public:
+  /**
+   * @brief generic constructor
+   */
   ServiceClientHandler(void){};
+
+  /**
+   * @brief generic destructor
+   */
   ~ServiceClientHandler(void){};
 
+  /**
+   * @brief operator=
+   *
+   * @param other
+   *
+   * @return
+   */
   ServiceClientHandler& operator=(const ServiceClientHandler& other);
 
+  /**
+   * @brief copy constructor
+   *
+   * @param other
+   */
   ServiceClientHandler(const ServiceClientHandler& other);
 
+  /**
+   * @brief constructor
+   *
+   * @param nh ROS node handler
+   * @param address service address
+   */
   ServiceClientHandler(ros::NodeHandle& nh, const std::string& address);
 
+  /**
+   * @brief initializer
+   *
+   * @param nh ROS node handler
+   * @param address service address
+   */
+  void initialize(ros::NodeHandle& nh, const std::string& address);
+
+  /**
+   * @brief "standard" synchronous call
+   *
+   * @param srv data
+   *
+   * @return true when success
+   */
   bool call(ServiceType& srv);
 
+  /**
+   * @brief "standard" synchronous call with repeats after failure
+   *
+   * @param srv data
+   * @param attempts how many attempts for the call
+   *
+   * @return true when success
+   */
   bool call(ServiceType& srv, const int& attempts);
 
+  /**
+   * @brief asynchronous call
+   *
+   * @param srv data
+   *
+   * @return future result
+   */
   std::future<ServiceType> callAsync(ServiceType& srv);
 
+  /**
+   * @brief asynchronous call with repeats after failure
+   *
+   * @param srv data
+   * @param attempts how many attemps for the call
+   *
+   * @return future result
+   */
   std::future<ServiceType> callAsync(ServiceType& srv, const int& attempts);
 
 private:

--- a/src/service_client_handler/example.cpp
+++ b/src/service_client_handler/example.cpp
@@ -9,12 +9,37 @@
 
 #include <std_srvs/Trigger.h>
 
-ros::ServiceServer                               server;
-mrs_lib::ServiceClientHandler<std_srvs::Trigger> client;
+ros::ServiceServer server1;
+ros::ServiceServer server2;
 
-bool callbackService([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+mrs_lib::ServiceClientHandler<std_srvs::Trigger> client1;
+mrs_lib::ServiceClientHandler<std_srvs::Trigger> client2;
 
-  ROS_INFO("[%s]: service call received", ros::this_node::getName().c_str());
+int counter_1 = 0;
+int counter_2 = 0;
+
+bool callbackService1([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+
+  ROS_INFO("[%s]: service call 1 received", ros::this_node::getName().c_str());
+
+  ros::Duration(1.0).sleep();
+
+  ROS_INFO("[%s]: service 1 call stopped", ros::this_node::getName().c_str());
+
+  ROS_INFO("[%s]: service 1 counter: %d", ros::this_node::getName().c_str(), counter_1++);
+
+  return true;
+}
+
+bool callbackService2([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+
+  ROS_INFO("[%s]: service call 2 received", ros::this_node::getName().c_str());
+
+  ros::Duration(1.0).sleep();
+
+  ROS_INFO("[%s]: service 2 call stopped", ros::this_node::getName().c_str());
+
+  ROS_INFO("[%s]: service 2 counter: %d", ros::this_node::getName().c_str(), counter_2++);
 
   return true;
 }
@@ -26,7 +51,9 @@ void threadMain(void) {
     ROS_INFO_ONCE("[%s]: thread spinning", ros::this_node::getName().c_str());
 
     std_srvs::Trigger srv;
-    client.call(srv);
+
+    std::future<std_srvs::Trigger> res = client1.callAsync(srv, 3);
+    client2.call(srv);
   }
 }
 
@@ -41,11 +68,13 @@ int main(int argc, char** argv) {
 
   // | ----------------- create a service server ---------------- |
 
-  ros::ServiceServer server = nh.advertiseService("service", callbackService);
+  ros::ServiceServer server1 = nh.advertiseService("service1", callbackService1);
+  ros::ServiceServer server2 = nh.advertiseService("service2", callbackService2);
 
   // | ----------------- create a service client ---------------- |
 
-  client = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service");
+  client1 = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service1");
+  client2 = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service2");
 
   // | ------------------------- thread ------------------------- |
 
@@ -53,15 +82,8 @@ int main(int argc, char** argv) {
 
   ROS_INFO("[%s]: initialized", ros::this_node::getName().c_str());
 
-  ros::Rate rate(100.0);
-
-  while (ros::ok()) {
-
-    ROS_INFO_ONCE("[%s]: spinning", ros::this_node::getName().c_str());
-
-    ros::spinOnce();
-    rate.sleep();
-  }
+  ros::MultiThreadedSpinner spinner(4);
+  spinner.spin();
 
   ROS_INFO("[%s]: finished", ros::this_node::getName().c_str());
 

--- a/src/service_client_handler/example.cpp
+++ b/src/service_client_handler/example.cpp
@@ -1,0 +1,71 @@
+#include "ros/init.h"
+#include <ros/node_handle.h>
+#include <mrs_lib/service_client_handler.h>
+
+#include <string>
+#include <ros/ros.h>
+
+#include <thread>
+
+#include <std_srvs/Trigger.h>
+
+ros::ServiceServer                               server;
+mrs_lib::ServiceClientHandler<std_srvs::Trigger> client;
+
+bool callbackService([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+
+  ROS_INFO("[%s]: service call received", ros::this_node::getName().c_str());
+
+  return true;
+}
+
+void threadMain(void) {
+
+  while (ros::ok()) {
+
+    ROS_INFO_ONCE("[%s]: thread spinning", ros::this_node::getName().c_str());
+
+    std_srvs::Trigger srv;
+    client.call(srv);
+  }
+}
+
+int main(int argc, char** argv) {
+
+  const std::string node_name("service_client_handler_example");
+
+  ros::init(argc, argv, node_name);
+  ros::NodeHandle nh = ros::NodeHandle("~");
+
+  ros::Time::waitForValid();
+
+  // | ----------------- create a service server ---------------- |
+
+  ros::ServiceServer server = nh.advertiseService("service", callbackService);
+
+  // | ----------------- create a service client ---------------- |
+
+  client = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service");
+
+  // | ------------------------- thread ------------------------- |
+
+  std::thread thread_main = std::thread(threadMain);
+
+  ROS_INFO("[%s]: initialized", ros::this_node::getName().c_str());
+
+  ros::Rate rate(100.0);
+
+  while (ros::ok()) {
+
+    ROS_INFO_ONCE("[%s]: spinning", ros::this_node::getName().c_str());
+
+    ros::spinOnce();
+    rate.sleep();
+  }
+
+  ROS_INFO("[%s]: finished", ros::this_node::getName().c_str());
+
+  ros::shutdown();
+
+  return 0;
+}

--- a/src/service_client_handler/example.cpp
+++ b/src/service_client_handler/example.cpp
@@ -1,10 +1,9 @@
-#include "ros/init.h"
-#include <ros/node_handle.h>
+#include <ros/ros.h>
+#include <ros/package.h>
+
 #include <mrs_lib/service_client_handler.h>
 
 #include <string>
-#include <ros/ros.h>
-
 #include <thread>
 
 #include <std_srvs/Trigger.h>
@@ -74,7 +73,7 @@ int main(int argc, char** argv) {
   // | ----------------- create a service client ---------------- |
 
   client1 = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service1");
-  client2 = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service2");
+  client2.initialize(nh, "service2");
 
   // | ------------------------- thread ------------------------- |
 

--- a/test/mrs_lib.test
+++ b/test/mrs_lib.test
@@ -24,6 +24,9 @@
   <include file="$(find mrs_lib)/test/repredictor/repredictor.test">
   </include>
 
+  <include file="$(find mrs_lib)/test/service_client_handler/service_client_handler.test">
+  </include>
+
   <!--
   <include file="$(find mrs_lib)/test/vector_converter/vector_converter.test">
   </include>

--- a/test/service_client_handler/service_client_handler.test
+++ b/test/service_client_handler/service_client_handler.test
@@ -1,0 +1,6 @@
+<launch>
+
+  <test pkg="mrs_lib" type="ServiceClientHandlerTest" test-name="service_client_handler_test" time-limit="10.0">
+  </test>
+
+</launch>

--- a/test/service_client_handler/test.cpp
+++ b/test/service_client_handler/test.cpp
@@ -1,0 +1,114 @@
+#include "ros/duration.h"
+#include "ros/spinner.h"
+#include <ros/ros.h>
+#include <ros/package.h>
+
+#include <mrs_lib/service_client_handler.h>
+
+#include <string>
+#include <thread>
+
+#include <std_srvs/Trigger.h>
+
+#include <gtest/gtest.h>
+#include <log4cxx/logger.h>
+
+ros::ServiceServer server;
+
+mrs_lib::ServiceClientHandler<std_srvs::Trigger> client;
+mrs_lib::ServiceClientHandler<std_srvs::Trigger> client2;
+
+using namespace mrs_lib;
+
+std::atomic<bool> service2_should_fail = true;
+
+bool callbackService([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+
+  res.message = "yes";
+  res.success = true;
+
+  ros::Duration(1.0).sleep();
+
+  service2_should_fail = false;
+
+  return true;
+}
+
+bool callbackFailedService([[maybe_unused]] std_srvs::Trigger::Request& req, [[maybe_unused]] std_srvs::Trigger::Response& res) {
+
+  res.message = "yes";
+  res.success = true;
+
+  ros::Duration(0.2).sleep();
+
+  if (service2_should_fail) {
+    ROS_INFO("[%s]: simulating service failure", ros::this_node::getName().c_str());
+    return false;
+  } else {
+    ROS_INFO("[%s]: service finally got through", ros::this_node::getName().c_str());
+    return true;
+  }
+}
+
+TEST(TESTSuite, main_test) {
+
+  ros::NodeHandle nh = ros::NodeHandle("~");
+
+  ros::Time::waitForValid();
+
+  // | ----------------- create a service server ---------------- |
+
+  ros::ServiceServer server1 = nh.advertiseService("service", callbackService);
+  ros::ServiceServer server2 = nh.advertiseService("service2", callbackFailedService);
+
+  // | ----------------- create a service client ---------------- |
+
+  client  = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service");
+  client2 = mrs_lib::ServiceClientHandler<std_srvs::Trigger>(nh, "service2");
+
+  ROS_INFO("[%s]: initialized", ros::this_node::getName().c_str());
+
+  bool success = true;
+
+  ros::AsyncSpinner spinner(10);
+  spinner.start();
+
+  std_srvs::Trigger srv;
+
+  std::future<std_srvs::Trigger> future_res  = client.callAsync(srv, 3);
+  std::future<std_srvs::Trigger> future2_res = client2.callAsync(srv, 10);
+
+  client.call(srv);
+  if (!srv.response.success) {
+    success = false;
+    ROS_ERROR("[%s]: normal service call failed", ros::this_node::getName().c_str());
+  }
+
+  future_res.wait();
+  if (!future_res.get().response.success) {
+    success = false;
+    ROS_ERROR("[%s]: async service call failed", ros::this_node::getName().c_str());
+  }
+
+  future2_res.wait();
+  if (!future2_res.get().response.success) {
+    success = false;
+    ROS_ERROR("[%s]: async failing service call failed", ros::this_node::getName().c_str());
+  }
+
+  ROS_INFO("[%s]: finished", ros::this_node::getName().c_str());
+
+  EXPECT_TRUE(success);
+}
+
+int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
+
+  ros::init(argc, argv, "ServiceClientHandlerTest");
+  ros::NodeHandle nh = ros::NodeHandle("~");
+
+  ros::Time::waitForValid();
+
+  testing::InitGoogleTest(&argc, argv);
+
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Check the diff. A deadlock might occur between
1. `topicName()` (which locks `m_mtx`) being called in `check_timeout()`, and
2. `process_new_message()` (being under `m_mtx`), calling `m_timeout_check_timer.stop()` that is blocking until it is sure no more `check_timeout()` will get called (aka, until 1. finishes).

GDB backtrace: [backtrace.txt](https://github.com/ctu-mrs/mrs_lib/files/6269713/backtrace.txt)
