### PR TITLE
Add address and UB sanitizers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,11 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3") # because normal r
 add_definitions(-Wall)
 add_definitions(-Wextra)
 add_definitions(-Wpedantic)
+add_definitions(-fno-omit-frame-pointer)
+add_definitions(-fsanitize=address,undefined)
+add_link_options(-fsanitize=address,undefined)
+set(-O0)
+set(-g)
 
 # include Eigen3
 find_package(Eigen3 REQUIRED)

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -27,7 +27,13 @@ roscore &
 rostest --reuse-master $PACKAGE mrs_lib.test $TEXT_OUTPUT --results-filename=$PACKAGE.test --results-base-dir="$TEST_RESULT_PATH"
 
 # evaluate the test results
+echo test result path is $TEST_RESULT_PATH
 catkin_test_results "$TEST_RESULT_PATH"
+success=$?
 
 echo ""
-echo "Success? $?"
+if [ $success = "0" ]; then
+  echo -e "\033[0;32mSuccess! \033[1;"
+else
+  echo -e "\033[0;31mFailed some tests! \033[1;"
+fi

--- a/test/subscribe_handler/test.cpp
+++ b/test/subscribe_handler/test.cpp
@@ -28,19 +28,12 @@ void message_callback(mrs_lib::SubscribeHandler<geometry_msgs::PointStamped>& sh
   got_messages_ = true;
 }
 
-mrs_lib::SubscribeHandler<geometry_msgs::PointStamped> sh;
-
-void thread_fcn([[maybe_unused]] const ros::TimerEvent& evt) {
-  if (sh.hasMsg()) {
-    ROS_INFO_STREAM_THROTTLE(1.0, "time of last message: " << sh.lastMsgTime());
-  }
-}
-
 /* TEST(TESTSuite, main_test) //{ */
 
 TEST(TESTSuite, main_test) {
 
   ros::NodeHandle nh("~");
+  mrs_lib::SubscribeHandler<geometry_msgs::PointStamped> sh;
 
   int result = 0;
 
@@ -63,7 +56,14 @@ TEST(TESTSuite, main_test) {
 
   std::vector<ros::Timer> timers;
   for (int it = 0; it < 200; it++) {
-    timers.push_back(nh.createTimer(ros::Duration(1e-3), thread_fcn));
+    timers.push_back(nh.createTimer(ros::Duration(1e-3), 
+    [&sh] ([[maybe_unused]] const ros::TimerEvent& evt)
+    {
+      if (sh.hasMsg()) {
+        ROS_INFO_STREAM_THROTTLE(1.0, "time of last message: " << sh.lastMsgTime());
+      }
+    }
+    ));
   }
 
   /* Type of the message may be accessed by C++11 decltype in case of need */


### PR DESCRIPTION
the sanitizers should only be enabled for debug, tests and CI. I propose adding the relevant flags to the `RelWithDebugInfo` catkin profile.