### PR TITLE
Updating CI - added sanitizers to debug build type

### DIFF
--- a/.ci/install.sh
+++ b/.ci/install.sh
@@ -30,9 +30,21 @@ rm -rf ~/uav_core/.gitman/$PACKAGE_NAME
 ln -s "$MY_PATH" ~/uav_core/.gitman/$PACKAGE_NAME
 
 mkdir -p ~/mrs_workspace/src
+cd ~/mrs_workspace
+source /opt/ros/$ROS_DISTRO/setup.bash
+command catkin init
+
+echo "$0: setting up build profiles"
+command catkin config --profile debug --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-std=c++17 -march=native' -DCMAKE_C_FLAGS='-march=native'
+command catkin config --profile release --cmake-args -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-std=c++17 -march=native' -DCMAKE_C_FLAGS='-march=native'
+command catkin config --profile reldeb --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DCMAKE_CXX_FLAGS='-std=c++17 -march=native' -DCMAKE_C_FLAGS='-march=native'
+
+# TRAVIS CI build
+# set debug for faster build
+command catkin profile set debug
+
 cd ~/mrs_workspace/src
 ln -s ~/uav_core
-source /opt/ros/$ROS_DISTRO/setup.bash
 cd ~/mrs_workspace
 
 echo "install ended"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,19 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 project(mrs_lib)
 
-# Override CXX flags inherited from workspace, if precompiled PCL binaries from debian repos are used
-if (DEFINED ENV{PCL_CROSS_COMPILATION})
-  set(PCL_CROSS_COMPILATION $ENV{PCL_CROSS_COMPILATION})
-else()
-  set(PCL_CROSS_COMPILATION "false")
-endif()
-if(${PCL_CROSS_COMPILATION} STREQUAL "false")
-  message("Using precompiled PCL binaries from debian repos. Overriding catkin workspace CMAKE_CXX_FLAGS.")
-  set(CMAKE_CXX_FLAGS "-std=c++17")
-else()
-  message("Using custom-built PCL binaries. Inheriting all CMAKE_CXX_FLAGS from catkin workspace.")
-endif()
-
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   cmake_modules
@@ -41,6 +28,10 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # please, NEVER commit those alternative flags with specific overrides of optimization
+#  add the address sanitizer compiler flags to debug build type
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address,undefined -fno-omit-frame-pointer") # because normal release is just -O2
+#  add the address sanitizer linker flags to debug build type
+set(CMAKE_LD_FLAGS_DEBUG  "${CMAKE_LD_FLAGS_DEBUG} -fno-omit-frame-pointer -fsanitize=address,undefined") # because normal release is just -O2
 set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -O3") # because normal release is just -O2
 # please, really do not commit your temporary custom flags :-)
 

--- a/test/repredictor/test.cpp
+++ b/test/repredictor/test.cpp
@@ -82,8 +82,8 @@ TEST(TESTSuite, lkf_comparison)
   // measurement noise is just identity
   const R_t R = 0.1*R_t::Identity();
   
-  const int n_gts = 5e2;
-  const int n_meass = 3e2;
+  const int n_gts = 2e2;
+  const int n_meass = 1e2;
 
   // Instantiate the LKF model
   auto lkf = std::make_shared<lkf_t>(generateA, generateB, H);

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -27,7 +27,13 @@ roscore &
 rostest --reuse-master $PACKAGE mrs_lib.test $TEXT_OUTPUT --results-filename=$PACKAGE.test --results-base-dir="$TEST_RESULT_PATH"
 
 # evaluate the test results
+echo test result path is $TEST_RESULT_PATH
 catkin_test_results "$TEST_RESULT_PATH"
+success=$?
 
 echo ""
-echo "Success? $?"
+if [ $success = "0" ]; then
+  echo -e "\033[0;32mSuccess! \033[1;"
+else
+  echo -e "\033[0;31mFailed some tests! \033[1;"
+fi

--- a/test/subscribe_handler/test.cpp
+++ b/test/subscribe_handler/test.cpp
@@ -28,19 +28,12 @@ void message_callback(mrs_lib::SubscribeHandler<geometry_msgs::PointStamped>& sh
   got_messages_ = true;
 }
 
-mrs_lib::SubscribeHandler<geometry_msgs::PointStamped> sh;
-
-void thread_fcn([[maybe_unused]] const ros::TimerEvent& evt) {
-  if (sh.hasMsg()) {
-    ROS_INFO_STREAM_THROTTLE(1.0, "time of last message: " << sh.lastMsgTime());
-  }
-}
-
 /* TEST(TESTSuite, main_test) //{ */
 
 TEST(TESTSuite, main_test) {
 
   ros::NodeHandle nh("~");
+  mrs_lib::SubscribeHandler<geometry_msgs::PointStamped> sh;
 
   int result = 0;
 
@@ -63,7 +56,14 @@ TEST(TESTSuite, main_test) {
 
   std::vector<ros::Timer> timers;
   for (int it = 0; it < 200; it++) {
-    timers.push_back(nh.createTimer(ros::Duration(1e-3), thread_fcn));
+    timers.push_back(nh.createTimer(ros::Duration(1e-3), 
+    [&sh] ([[maybe_unused]] const ros::TimerEvent& evt)
+    {
+      if (sh.hasMsg()) {
+        ROS_INFO_STREAM_THROTTLE(1.0, "time of last message: " << sh.lastMsgTime());
+      }
+    }
+    ));
   }
 
   /* Type of the message may be accessed by C++11 decltype in case of need */


### PR DESCRIPTION
Added address and undefined behavior sanitizers to the `debug` build type, and updated CI to use this build type.

Also fixes `-march=native` flag selection (now on iregardles of whether PCL is manually built or from apt).