### PR TITLE
Enable SubscribeHandler to use either ROSTimer or ThreadTimer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.1.2)
 project(mrs_lib)
-set(CMAKE_BUILD_TYPE Debug)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp
@@ -408,6 +407,7 @@ if(CATKIN_ENABLE_TESTING)
   )
   target_link_libraries(
     SubscribeHandlerTest
+    MrsLibTimer 
     ${catkin_LIBRARIES}
   )
   add_dependencies(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.1.2)
 project(mrs_lib)
+set(CMAKE_BUILD_TYPE Debug)
 
 find_package(catkin REQUIRED COMPONENTS
   roscpp

--- a/include/impl/subscribe_handler.hpp
+++ b/include/impl/subscribe_handler.hpp
@@ -4,335 +4,349 @@
 #define SUBSCRIBE_HANDLER_HPP
 
 #include <mrs_lib/subscribe_handler.h>
+#include <mrs_lib/timer.h>
 #include <mutex>
 #include <condition_variable>
 
 namespace mrs_lib
 {
-  namespace impl
+  /* SubscribeHandler::Impl class //{ */
+  // implements the constructor, getMsg() method and data_callback method (non-thread-safe)
+  template <typename MessageType>
+  class SubscribeHandler<MessageType>::Impl
   {
+  public:
+    using timeout_callback_t = typename SubscribeHandler<MessageType>::timeout_callback_t;
+    using message_callback_t = typename SubscribeHandler<MessageType>::message_callback_t;
+    using data_callback_t = std::function<void(const typename MessageType::ConstPtr&)>;
 
-    /* SubscribeHandler_impl class //{ */
-    // implements the constructor, getMsg() method and data_callback method (non-thread-safe)
-    template <typename MessageType>
-    class SubscribeHandler_impl : public SubscribeHandler<MessageType>
+  private:
+    friend class SubscribeHandler<MessageType>;
+
+  public:
+    /* constructor //{ */
+    Impl(SubscribeHandler* owner, const SubscribeHandlerOptions& options, const message_callback_t& message_callback = message_callback_t())
+        : m_owner(owner),
+          m_nh(options.nh),
+          m_no_message_timeout(options.no_message_timeout),
+          m_topic_name(options.topic_name),
+          m_node_name(options.node_name),
+          m_got_data(false),
+          m_new_data(false),
+          m_used_data(false),
+          m_last_msg_received(ros::Time::now()),
+          m_timeout_callback(options.timeout_callback),
+          m_message_callback(message_callback),
+          m_queue_size(options.queue_size),
+          m_transport_hints(options.transport_hints)
     {
-    public:
-      using timeout_callback_t = typename SubscribeHandler<MessageType>::timeout_callback_t;
-      using message_callback_t = typename SubscribeHandler<MessageType>::message_callback_t;
-      using data_callback_t = std::function<void(const typename MessageType::ConstPtr&)>;
+      std::cout << "impl constructor address: " << owner << "\n";
+      if (!m_timeout_callback)
+        m_timeout_callback = std::bind(&Impl::default_timeout_callback, this, std::placeholders::_1, std::placeholders::_2,
+                                       std::placeholders::_3);
 
-    private:
-      friend class SubscribeHandler<MessageType>;
-
-    public:
-      /* constructor //{ */
-      SubscribeHandler_impl(const SubscribeHandlerOptions& options, const message_callback_t& message_callback = message_callback_t())
-          : m_nh(options.nh),
-            m_no_message_timeout(options.no_message_timeout),
-            m_topic_name(options.topic_name),
-            m_node_name(options.node_name),
-            m_got_data(false),
-            m_new_data(false),
-            m_used_data(false),
-            m_last_msg_received(ros::Time::now()),
-            m_timeout_callback(options.timeout_callback),
-            m_message_callback(message_callback),
-            m_queue_size(options.queue_size),
-            m_transport_hints(options.transport_hints)
+      if (options.no_message_timeout != mrs_lib::no_timeout)
       {
-        if (!m_timeout_callback)
-          m_timeout_callback = std::bind(&SubscribeHandler_impl<MessageType>::default_timeout_callback, this, std::placeholders::_1, std::placeholders::_2,
-                                         std::placeholders::_3);
-
-        if (options.no_message_timeout != mrs_lib::no_timeout)
-          m_timeout_check_timer =
-              m_nh.createTimer(options.no_message_timeout, &SubscribeHandler_impl<MessageType>::check_timeout, this, true /*oneshot*/, false /*autostart*/);
-
-        const std::string msg = "Subscribed to topic '" + m_topic_name + "' -> '" + topicName() + "'";
-        if (m_node_name.empty())
-          ROS_INFO_STREAM(msg);
+        if (options.use_thread_timer)
+          m_timeout_check_timer = std::make_unique<mrs_lib::ThreadTimer>(m_nh, options.no_message_timeout, &Impl::check_timeout, this, true /*oneshot*/, false /*autostart*/);
         else
-          ROS_INFO_STREAM("[" << m_node_name << "]: " << msg);
+          m_timeout_check_timer = std::make_unique<mrs_lib::ROSTimer>(m_nh, options.no_message_timeout, &Impl::check_timeout, this, true /*oneshot*/, false /*autostart*/);
       }
-      //}
 
-      virtual ~SubscribeHandler_impl() override = default;
+      const std::string msg = "Subscribed to topic '" + m_topic_name + "' -> '" + topicName() + "'";
+      if (m_node_name.empty())
+        ROS_INFO_STREAM(msg);
+      else
+        ROS_INFO_STREAM("[" << m_node_name << "]: " << msg);
+    }
+    //}
 
-    public:
-      /* getMsg() method //{ */
-      virtual typename MessageType::ConstPtr getMsg() override
-      {
-        m_new_data = false;
-        m_used_data = true;
-        return peekMsg();
-      }
-      //}
+    virtual ~Impl() = default;
 
-      /* peekMsg() method //{ */
-      virtual typename MessageType::ConstPtr peekMsg() override
-      {
-        assert(m_got_data);
-        if (!m_got_data)
-          ROS_ERROR("[%s]: No data received yet from topic '%s' (forgot to check hasMsg()?)! Returning empty message.", m_node_name.c_str(),
-                    topicName().c_str());
-        return m_latest_message;
-      }
-      //}
+  public:
+    /* getMsg() method //{ */
+    virtual typename MessageType::ConstPtr getMsg()
+    {
+      m_new_data = false;
+      m_used_data = true;
+      return peekMsg();
+    }
+    //}
 
-      /* hasMsg() method //{ */
-      virtual bool hasMsg() const override
-      {
-        return m_got_data;
-      }
-      //}
+    /* peekMsg() method //{ */
+    virtual typename MessageType::ConstPtr peekMsg()
+    {
+      assert(m_got_data);
+      if (!m_got_data)
+        ROS_ERROR("[%s]: No data received yet from topic '%s' (forgot to check hasMsg()?)! Returning empty message.", m_node_name.c_str(),
+                  topicName().c_str());
+      return m_latest_message;
+    }
+    //}
 
-      /* newMsg() method //{ */
-      virtual bool newMsg() const override
-      {
-        return m_new_data;
-      }
-      //}
+    /* hasMsg() method //{ */
+    virtual bool hasMsg() const
+    {
+      return m_got_data;
+    }
+    //}
 
-      /* usedMsg() method //{ */
-      virtual bool usedMsg() const override
-      {
-        return m_used_data;
-      }
-      //}
+    /* newMsg() method //{ */
+    virtual bool newMsg() const
+    {
+      return m_new_data;
+    }
+    //}
 
-      /* waitForNew() method //{ */
-      virtual typename MessageType::ConstPtr waitForNew(const ros::WallDuration& timeout) override
-      {
-        // convert the ros type to chrono type
-        const std::chrono::duration<float> chrono_timeout(timeout.toSec());
-        // lock the mutex guarding the m_new_data flag
-        std::unique_lock lock(m_new_data_mtx);
-        // if new data is available, return immediately, otherwise attempt to wait for new data using the respective condition variable
-        if (m_new_data)
-          return getMsg();
-        else if (m_new_data_cv.wait_for(lock, chrono_timeout) == std::cv_status::no_timeout && m_new_data)
-          return getMsg();
-        else
-          return nullptr;
-      };
-      //}
+    /* usedMsg() method //{ */
+    virtual bool usedMsg() const
+    {
+      return m_used_data;
+    }
+    //}
 
-      /* lastMsgTime() method //{ */
-      virtual ros::Time lastMsgTime() const override
+    /* waitForNew() method //{ */
+    virtual typename MessageType::ConstPtr waitForNew(const ros::WallDuration& timeout)
+    {
+      // convert the ros type to chrono type
+      const std::chrono::duration<float> chrono_timeout(timeout.toSec());
+      // lock the mutex guarding the m_new_data flag
+      std::unique_lock lock(m_new_data_mtx);
+      // if new data is available, return immediately, otherwise attempt to wait for new data using the respective condition variable
+      if (m_new_data)
+        return getMsg();
+      else if (m_new_data_cv.wait_for(lock, chrono_timeout) == std::cv_status::no_timeout && m_new_data)
+        return getMsg();
+      else
+        return nullptr;
+    };
+    //}
+
+    /* lastMsgTime() method //{ */
+    virtual ros::Time lastMsgTime() const
+    {
+      std::lock_guard lck(m_last_msg_received_mtx);
+      return m_last_msg_received;
+    };
+    //}
+
+    /* topicName() method //{ */
+    virtual std::string topicName() const
+    {
+      std::string ret = m_sub.getTopic();
+      if (ret.empty())
+        ret = m_nh.resolveName(m_topic_name);
+      return ret;
+    }
+    //}
+
+    /* start() method //{ */
+    virtual void start()
+    {
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->start();
+      m_sub = m_nh.subscribe(m_topic_name, m_queue_size, &Impl::data_callback, this, m_transport_hints);
+    }
+    //}
+
+    /* stop() method //{ */
+    virtual void stop()
+    {
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->stop();
+      m_sub.shutdown();
+    }
+    //}
+
+  protected:
+    /* check_time_reset() method //{ */
+    bool check_time_reset(const ros::Time& now)
+    {
+      return now < m_last_msg_received;
+    }
+    //}
+
+  protected:
+    SubscribeHandler* m_owner;
+    ros::NodeHandle m_nh;
+    ros::Subscriber m_sub;
+
+  protected:
+    ros::Duration m_no_message_timeout;
+    std::string m_topic_name;
+    std::string m_node_name;
+
+  protected:
+    bool m_got_data;   // whether any data was received
+
+    mutable std::mutex m_new_data_mtx;
+    mutable std::condition_variable m_new_data_cv;
+    bool m_new_data;   // whether new data was received since last call to get_data
+
+    bool m_used_data;  // whether get_data was successfully called at least once
+
+  protected:
+    mutable std::mutex m_last_msg_received_mtx;
+    ros::Time m_last_msg_received;
+    std::unique_ptr<mrs_lib::MRSTimer> m_timeout_check_timer;
+    timeout_callback_t m_timeout_callback;
+
+  protected:
+    typename MessageType::ConstPtr m_latest_message;
+    message_callback_t m_message_callback;
+
+  private:
+    uint32_t m_queue_size;
+    ros::TransportHints m_transport_hints;
+
+  protected:
+    /* default_timeout_callback() method //{ */
+    void default_timeout_callback(const std::string& topic, const ros::Time& last_msg, const int n_pubs)
+    {
+      /* ROS_ERROR("Checking topic %s, delay: %.2f", m_sub.getTopic().c_str(), since_msg.toSec()); */
+      ros::Duration since_msg = (ros::Time::now() - last_msg);
+      const std::string msg = "Did not receive any message from topic '" + topic + "' for " + std::to_string(since_msg.toSec()) + "s ("
+                              + std::to_string(n_pubs) + " publishers on this topic)";
+      if (m_node_name.empty())
+        ROS_WARN_STREAM(msg);
+      else
+        ROS_WARN_STREAM("[" << m_node_name << "]: " << msg);
+    }
+    //}
+
+    /* check_timeout() method //{ */
+    void check_timeout([[maybe_unused]] const ros::TimerEvent& evt)
+    {
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->stop();
+      ros::Time last_msg;
       {
         std::lock_guard lck(m_last_msg_received_mtx);
-        return m_last_msg_received;
-      };
-      //}
-
-      /* topicName() method //{ */
-      virtual std::string topicName() const override
-      {
-        std::string ret = m_sub.getTopic();
-        if (ret.empty())
-          ret = m_nh.resolveName(m_topic_name);
-        return ret;
+        last_msg = m_last_msg_received;
       }
-      //}
-
-      /* start() method //{ */
-      virtual void start() override
-      {
-        m_timeout_check_timer.start();
-        m_sub = m_nh.subscribe(m_topic_name, m_queue_size, &SubscribeHandler_impl<MessageType>::data_callback, this, m_transport_hints);
-      }
-      //}
-
-      /* stop() method //{ */
-      virtual void stop() override
-      {
-        m_timeout_check_timer.stop();
-        m_sub.shutdown();
-      }
-      //}
-
-    protected:
-      /* check_time_reset() method //{ */
-      bool check_time_reset(const ros::Time& now)
-      {
-        return now < m_last_msg_received;
-      }
-      //}
-
-    protected:
-      ros::NodeHandle m_nh;
-      ros::Subscriber m_sub;
-
-    protected:
-      ros::Duration m_no_message_timeout;
-      std::string m_topic_name;
-      std::string m_node_name;
-
-    protected:
-      bool m_got_data;   // whether any data was received
-
-      mutable std::mutex m_new_data_mtx;
-      mutable std::condition_variable m_new_data_cv;
-      bool m_new_data;   // whether new data was received since last call to get_data
-
-      bool m_used_data;  // whether get_data was successfully called at least once
-
-    protected:
-      mutable std::mutex m_last_msg_received_mtx;
-      ros::Time m_last_msg_received;
-      ros::Timer m_timeout_check_timer;
-      timeout_callback_t m_timeout_callback;
-
-    protected:
-      typename MessageType::ConstPtr m_latest_message;
-      message_callback_t m_message_callback;
-
-    private:
-      uint32_t m_queue_size;
-      ros::TransportHints m_transport_hints;
-
-    protected:
-      /* default_timeout_callback() method //{ */
-      void default_timeout_callback(const std::string& topic, const ros::Time& last_msg, const int n_pubs)
-      {
-        /* ROS_ERROR("Checking topic %s, delay: %.2f", m_sub.getTopic().c_str(), since_msg.toSec()); */
-        ros::Duration since_msg = (ros::Time::now() - last_msg);
-        const std::string msg = "Did not receive any message from topic '" + topic + "' for " + std::to_string(since_msg.toSec()) + "s ("
-                                + std::to_string(n_pubs) + " publishers on this topic)";
-        if (m_node_name.empty())
-          ROS_WARN_STREAM(msg);
-        else
-          ROS_WARN_STREAM("[" << m_node_name << "]: " << msg);
-      }
-      //}
-
-      /* check_timeout() method //{ */
-      void check_timeout([[maybe_unused]] const ros::TimerEvent& evt)
-      {
-        m_timeout_check_timer.stop();
-        ros::Time last_msg;
-        {
-          std::lock_guard lck(m_last_msg_received_mtx);
-          last_msg = m_last_msg_received;
-        }
-        const auto n_pubs = m_sub.getNumPublishers();
-        m_timeout_check_timer.start();
-        m_timeout_callback(topicName(), last_msg, n_pubs);
-      }
-      //}
-
-      /* process_new_message() method //{ */
-      void process_new_message(const typename MessageType::ConstPtr& msg)
-      {
-        m_latest_message = msg;
-        m_new_data = true;
-        m_got_data = true;
-        m_last_msg_received = ros::Time::now();
-        m_new_data_cv.notify_one();
-      }
-      //}
-
-      /* data_callback() method //{ */
-      virtual void data_callback(const typename MessageType::ConstPtr& msg)
-      {
-        m_timeout_check_timer.stop();
-        std::lock_guard lck(m_new_data_mtx);
-        process_new_message(msg);
-        if (m_message_callback)
-          m_message_callback(*this);
-        m_timeout_check_timer.start();
-      }
-      //}
-    };
+      const auto n_pubs = m_sub.getNumPublishers();
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->start();
+      m_timeout_callback(topicName(), last_msg, n_pubs);
+    }
     //}
 
-    /* SubscribeHandler_threadsafe class //{ */
-    template <typename MessageType>
-    class SubscribeHandler_threadsafe final : public SubscribeHandler_impl<MessageType>
+    /* process_new_message() method //{ */
+    void process_new_message(const typename MessageType::ConstPtr& msg)
     {
-    private:
-      using impl_class_t = impl::SubscribeHandler_impl<MessageType>;
-
-    public:
-      using timeout_callback_t = typename impl_class_t::timeout_callback_t;
-      using message_callback_t = typename impl_class_t::message_callback_t;
-
-      friend class SubscribeHandler<MessageType>;
-
-    public:
-      SubscribeHandler_threadsafe(const SubscribeHandlerOptions& options, const message_callback_t& message_callback = message_callback_t())
-          : impl_class_t::SubscribeHandler_impl(options, message_callback)
-      {
-      }
-
-    public:
-      virtual bool hasMsg() const override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::hasMsg();
-      }
-      virtual bool newMsg() const override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::newMsg();
-      }
-      virtual bool usedMsg() const override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::usedMsg();
-      }
-      virtual typename MessageType::ConstPtr getMsg() override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::getMsg();
-      }
-      virtual typename MessageType::ConstPtr peekMsg() override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::peekMsg();
-      }
-      virtual ros::Time lastMsgTime() const override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::lastMsgTime();
-      };
-      virtual std::string topicName() const override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::topicName();
-      };
-      virtual void start() override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::start();
-      }
-      virtual void stop() override
-      {
-        std::lock_guard<std::recursive_mutex> lck(m_mtx);
-        return impl_class_t::stop();
-      }
-
-    protected:
-      virtual void data_callback(const typename MessageType::ConstPtr& msg) override
-      {
-        // the stop has to come before the mutex lock to enable the timer callbacks currently
-        // in the queue to execute and prevent deadlock (.stop() waits for all currently
-        // queued callbacks to finish before returning...)
-        this->m_timeout_check_timer.stop();
-        std::scoped_lock lck(m_mtx, this->m_new_data_mtx);
-        this->process_new_message(msg);
-        if (this->m_message_callback)
-          this->m_message_callback(*this);
-        this->m_timeout_check_timer.start();
-      }
-
-    private:
-      mutable std::recursive_mutex m_mtx;
-    };
+      m_latest_message = msg;
+      m_new_data = true;
+      m_got_data = true;
+      m_last_msg_received = ros::Time::now();
+      m_new_data_cv.notify_one();
+    }
     //}
 
-  }  // namespace impl
+    /* data_callback() method //{ */
+    virtual void data_callback(const typename MessageType::ConstPtr& msg)
+    {
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->stop();
+      std::lock_guard lck(m_new_data_mtx);
+      process_new_message(msg);
+      if (m_message_callback)
+        m_message_callback(*m_owner);
+      if (m_timeout_check_timer)
+        m_timeout_check_timer->start();
+    }
+    //}
+  };
+  //}
+
+  /* SubscribeHandler_threadsafe class //{ */
+  template <typename MessageType>
+  class SubscribeHandler<MessageType>::ImplThreadsafe : public SubscribeHandler<MessageType>::Impl
+  {
+  private:
+    using impl_class_t = SubscribeHandler<MessageType>::Impl;
+
+  public:
+    using timeout_callback_t = typename impl_class_t::timeout_callback_t;
+    using message_callback_t = typename impl_class_t::message_callback_t;
+
+    friend class SubscribeHandler<MessageType>;
+
+  public:
+    ImplThreadsafe(SubscribeHandler* owner, const SubscribeHandlerOptions& options, const message_callback_t& message_callback = message_callback_t())
+        : impl_class_t::Impl(owner, options, message_callback)
+    {
+      std::cout << "implThreadsafe constructor address: " << owner << "\n";
+    }
+
+  public:
+    virtual bool hasMsg() const override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::hasMsg();
+    }
+    virtual bool newMsg() const override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::newMsg();
+    }
+    virtual bool usedMsg() const override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::usedMsg();
+    }
+    virtual typename MessageType::ConstPtr getMsg() override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::getMsg();
+    }
+    virtual typename MessageType::ConstPtr peekMsg() override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::peekMsg();
+    }
+    virtual ros::Time lastMsgTime() const override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::lastMsgTime();
+    };
+    virtual std::string topicName() const override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::topicName();
+    };
+    virtual void start() override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::start();
+    }
+    virtual void stop() override
+    {
+      std::lock_guard<std::recursive_mutex> lck(m_mtx);
+      return impl_class_t::stop();
+    }
+
+    virtual ~ImplThreadsafe() override = default;
+
+  protected:
+    virtual void data_callback(const typename MessageType::ConstPtr& msg) override
+    {
+      // the stop has to come before the mutex lock to enable the timer callbacks currently
+      // in the queue to execute and prevent deadlock (.stop() waits for all currently
+      // queued callbacks to finish before returning...)
+      if (this->m_timeout_check_timer)
+        this->m_timeout_check_timer->stop();
+      std::scoped_lock lck(m_mtx, this->m_new_data_mtx);
+      this->process_new_message(msg);
+      if (this->m_message_callback)
+        this->m_message_callback(*(this->m_owner));
+      if (this->m_timeout_check_timer)
+        this->m_timeout_check_timer->start();
+    }
+
+  private:
+    mutable std::recursive_mutex m_mtx;
+  };
+  //}
 
 }  // namespace mrs_lib
 

--- a/include/impl/timer.hpp
+++ b/include/impl/timer.hpp
@@ -5,116 +5,85 @@
 
 /* ROSTimer constructors //{ */
 
-// rate
-template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj) {
-  *this = ROSTimer(nh, rate, callback, obj, false, true);
-}
-
-// duration
-template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                   ObjectType* const obj) {
-  *this = ROSTimer(nh, duration, callback, obj, false, true);
-}
-
-// rate + oneshot
-template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-                   const bool& oneshot) {
-  *this = ROSTimer(nh, rate, callback, obj, oneshot, true);
-}
-
-// duration + oneshot
-template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                   ObjectType* const obj, const bool& oneshot) {
-  *this = ROSTimer(nh, duration, callback, obj, oneshot, true);
-}
-
 // duration + oneshot + autostart
 template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                   ObjectType* const obj, const bool& oneshot, const bool& autostart) {
+ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent&),
+                   ObjectType* const obj, const bool oneshot, const bool autostart) {
 
-  this->timer_ = std::make_shared<ros::Timer>(nh.createTimer(duration, callback, obj, oneshot, autostart));
+  this->timer_ = std::make_unique<ros::Timer>(nh.createTimer(duration, callback, obj, oneshot, autostart));
 }
 
 // rate + oneshot + autostart
 template <class ObjectType>
-ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-                   const bool& oneshot, const bool& autostart) {
+ROSTimer::ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj,
+                   const bool oneshot, const bool autostart) {
 
-  this->timer_ = std::make_shared<ros::Timer>(nh.createTimer(rate, callback, obj, oneshot, autostart));
+  this->timer_ = std::make_unique<ros::Timer>(nh.createTimer(rate, callback, obj, oneshot, autostart));
 }
 
 //}
 
 // | ----------------------- ThreadTimer ---------------------- |
 
+/* class ThreadTimer::Impl //{ */
+
+class ThreadTimer::Impl {
+public:
+  Impl(const std::function<void(const ros::TimerEvent&)>& callback, const ros::Duration& delay_dur, const bool oneshot);
+  ~Impl();
+
+  void start();
+  void stop();
+  void setPeriod(const ros::Duration& duration, const bool reset = true);
+
+  friend class ThreadTimer;
+
+  // to keep rule of five since we have a custom destructor
+  Impl(const Impl&) = delete;
+  Impl(Impl&&) = delete;
+  Impl& operator=(const Impl&) = delete;
+  Impl& operator=(Impl&&) = delete;
+
+private:
+  std::thread thread_;
+  std::function<void(const ros::TimerEvent&)> callback_;
+
+  bool oneshot_;
+
+  void threadFcn();
+
+  std::mutex mutex_state_;
+  std::condition_variable start_cond_;
+  bool running_;
+  ros::Duration delay_dur_;
+  bool ending_;
+  ros::Time next_expected_;
+  ros::Time last_expected_;
+  ros::Time last_real_;
+
+};
+
+//}
+
 /* ThreadTimer constructors and destructors//{ */
 
 template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                         ObjectType* const obj) {
-
-  *this = ThreadTimer(nh, rate, callback, obj, false, true);
+ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent&),
+                         ObjectType* const obj, const bool oneshot, const bool autostart)
+  : ThreadTimer(nh, ros::Duration(rate), callback, obj, ros::Duration(rate), oneshot, autostart)
+{
 }
 
 template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Duration&                    duration,
-                         void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj) {
-
-  *this = ThreadTimer(nh, duration, callback, obj, false, true);
-}
-
-template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                         ObjectType* const obj, const bool& oneshot) {
-
-  *this = ThreadTimer(nh, rate, callback, obj, oneshot, true);
-}
-
-template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Duration&                    duration,
-                         void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj, const bool& oneshot) {
-
-  *this = ThreadTimer(nh, duration, callback, obj, oneshot, true);
-}
-
-template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-                         ObjectType* const obj, const bool& oneshot, const bool& autostart) {
-
-  this->impl_            = std::make_shared<Impl>();
-  this->impl_->callback_ = std::bind(callback, obj, std::placeholders::_1);
-  this->impl_->oneshot_  = oneshot;
-  this->impl_->rate_     = rate;
-  this->impl_->duration_ = rate.expectedCycleTime();
-
-  if (autostart) {
+ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Duration& duration,
+                         void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj, bool oneshot, const bool autostart) 
+{
+  const auto cbk = std::bind(callback, obj, std::placeholders::_1);
+  if (duration == ros::Duration(0))
+    oneshot = true;
+  this->impl_ = std::make_unique<Impl>(cbk, duration, oneshot);
+  if (autostart)
     this->impl_->start();
-  }
-}
-
-template <class ObjectType>
-ThreadTimer::ThreadTimer([[maybe_unused]] const ros::NodeHandle& nh, const ros::Duration&                    duration,
-                         void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj, const bool& oneshot, const bool& autostart) {
-
-  this->impl_            = std::make_shared<Impl>();
-  this->impl_->callback_ = std::bind(callback, obj, std::placeholders::_1);
-  this->impl_->oneshot_  = oneshot;
-  this->impl_->duration_ = duration;
-
-  if (duration.toSec() > 0) {
-    this->impl_->rate_ = 1.0 / duration.toSec();
-  } else {
-    this->impl_->oneshot_ = true;
-  }
-
-  if (autostart) {
-    this->impl_->start();
-  }
 }
 
 //}

--- a/include/mrs_lib/timer.h
+++ b/include/mrs_lib/timer.h
@@ -9,327 +9,186 @@
 namespace mrs_lib
 {
 
-// | ------------------------ ROSTimer ------------------------ |
+  class MRSTimer
+  {
+    public:
 
-/* class ROSTimer //{ */
+    MRSTimer() = default;
 
-/**
- * @brief ros::Timer wrapper. The interface is the same as with ros::Timer, except for the initialization method.
- */
-class ROSTimer {
-public:
-  ROSTimer(void);
-  ~ROSTimer(void);
+    /**
+     * @brief stop the timer
+     */
+    virtual void stop() = 0;
 
-  /**
-   * @brief copy constructor
-   *
-   * @param other
-   */
-  ROSTimer(const ROSTimer& other);
+    /**
+     * @brief start the timer
+     */
+    virtual void start() = 0;
 
-  /**
-   * @brief assignment operator
-   *
-   * @param other
-   *
-   * @return
-   */
-  ROSTimer& operator=(const ROSTimer& other);
+    /**
+     * @brief set the timer period/duration
+     *
+     * @param duration
+     * @param reset
+     */
+    virtual void setPeriod(const ros::Duration& duration, const bool reset = true) = 0;
 
-  /**
-   * @brief constructor, oneshot = false, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param rate
-   * @param ObjectType::*const callback
-   * @param obj
-   */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj);
+    virtual ~MRSTimer() = default;
+    MRSTimer(const MRSTimer&) = default;
+    MRSTimer(MRSTimer&&) = default;
+    MRSTimer& operator=(const MRSTimer&) = default;
+    MRSTimer& operator=(MRSTimer&&) = default;
+  };
+
+  // | ------------------------ ROSTimer ------------------------ |
+
+  /* class ROSTimer //{ */
 
   /**
-   * @brief constructor, oneshot = false, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
+   * @brief ros::Timer wrapper. The interface is the same as with ros::Timer, except for the initialization method.
    */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj);
+  class ROSTimer : public MRSTimer {
+  public:
+    ROSTimer();
+
+    /**
+     * @brief full constructor
+     *
+     * @tparam ObjectType
+     * @param nh
+     * @param rate
+     * @param ObjectType::*const callback
+     * @param obj
+     * @param oneshot
+     * @param autostart
+     */
+    template <class ObjectType>
+    ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj,
+             const bool oneshot = false, const bool autostart = true);
+
+    /**
+     * @brief full constructor
+     *
+     * @tparam ObjectType
+     * @param nh
+     * @param duration
+     * @param ObjectType::*const callback
+     * @param obj
+     * @param oneshot
+     * @param autostart
+     */
+    template <class ObjectType>
+    ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj,
+             const bool oneshot = false, const bool autostart = true);
+
+    /**
+     * @brief stop the timer
+     */
+    virtual void stop() override;
+
+    /**
+     * @brief start the timer
+     */
+    virtual void start() override;
+
+    /**
+     * @brief set the timer period/duration
+     *
+     * @param duration
+     * @param reset
+     */
+    virtual void setPeriod(const ros::Duration& duration, const bool reset = true) override;
+
+    virtual ~ROSTimer() override {stop();};
+    // to keep rule of five since we have a custom destructor
+    ROSTimer(const ROSTimer&) = delete;
+    ROSTimer(ROSTimer&&) = delete;
+    ROSTimer& operator=(const ROSTimer&) = delete;
+    ROSTimer& operator=(ROSTimer&&) = delete;
+
+  private:
+    std::mutex mutex_timer_;
+
+    std::unique_ptr<ros::Timer> timer_;
+  };
+
+  //}
+
+  // | ----------------------- ThreadTimer ---------------------- |
+
+  /* class ThreadTimer //{ */
 
   /**
-   * @brief constructor, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param rate
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
+   * @brief Custom thread-based Timers with the same interface as mrs_lib::ROSTimer.
    */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-           const bool& oneshot);
+  class ThreadTimer : public MRSTimer {
 
-  /**
-   * @brief constructor, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-           const bool& oneshot);
+  public:
+    ThreadTimer();
 
-  /**
-   * @brief full constructor
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param rate
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   * @param autostart
-   */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-           const bool& oneshot, const bool& autostart);
+    /**
+     * @brief full constructor
+     *
+     * @tparam ObjectType
+     * @param nh
+     * @param rate
+     * @param ObjectType::*const callback
+     * @param obj
+     * @param oneshot
+     * @param autostart
+     */
+    template <class ObjectType>
+    ThreadTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj,
+                const bool oneshot = false, const bool autostart = true);
 
-  /**
-   * @brief full constructor
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   * @param autostart
-   */
-  template <class ObjectType>
-  ROSTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-           const bool& oneshot, const bool& autostart);
+    /**
+     * @brief full constructor
+     *
+     * @tparam ObjectType
+     * @param nh
+     * @param duration
+     * @param ObjectType::*const callback
+     * @param obj
+     * @param oneshot
+     * @param autostart
+     */
+    template <class ObjectType>
+    ThreadTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent&), ObjectType* const obj,
+                bool oneshot = false, const bool autostart = true);
 
-  /**
-   * @brief stop the timer
-   */
-  void stop(void);
+    /**
+     * @brief stop the timer
+     */
+    virtual void stop() override;
 
-  /**
-   * @brief start the timer
-   */
-  void start(void);
+    /**
+     * @brief start the timer
+     */
+    virtual void start() override;
 
-  /**
-   * @brief set the timer period/duration
-   *
-   * @param duration
-   * @param reset
-   */
-  void setPeriod(const ros::Duration& duration, const bool& reset = true);
+    /**
+     * @brief set the timer period/duration
+     *
+     * @param duration
+     * @param reset
+     */
+    virtual void setPeriod(const ros::Duration& duration, const bool reset = true) override;
 
-private:
-  std::mutex mutex_timer_;
+    virtual ~ThreadTimer() override {stop();};
+    // to keep rule of five since we have a custom destructor
+    ThreadTimer(const ThreadTimer&) = delete;
+    ThreadTimer(ThreadTimer&&) = delete;
+    ThreadTimer& operator=(const ThreadTimer&) = delete;
+    ThreadTimer& operator=(ThreadTimer&&) = delete;
 
-  std::shared_ptr<ros::Timer> timer_;
-};
+  private:
+    class Impl;
 
-//}
+    std::unique_ptr<Impl> impl_;
 
-// | ----------------------- ThreadTimer ---------------------- |
+  };  // namespace mrs_lib
 
-/* class ThreadTimer //{ */
-
-/**
- * @brief Custom thread-based Timers with the same interface as mrs_lib::ROSTimer.
- */
-class ThreadTimer {
-
-public:
-  ThreadTimer();
-  ~ThreadTimer();
-
-  /**
-   * @brief copy constructor
-   *
-   * @param other
-   */
-  ThreadTimer(const ThreadTimer& other);
-
-  /**
-   * @brief assignment operator
-   *
-   * @param other
-   *
-   * @return ThreadTimer
-   */
-  ThreadTimer& operator=(const ThreadTimer& other);
-
-  /**
-   * @brief constructor, oneshot = false, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh node handle
-   * @param rate ros::Rate
-   * @param ObjectType::*const callback
-   * @param obj
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj);
-
-  /**
-   * @brief constructor, oneshot = false, autostart = true
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event),
-              ObjectType* const obj);
-
-  /**
-   * @brief constructor, autostart = false
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param rate
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-              const bool& oneshot);
-
-  /**
-   * @brief constructor, autostart = false
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-              const bool& oneshot);
-
-  /**
-   * @brief full constructor
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param rate
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   * @param autostart
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Rate& rate, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-              const bool& oneshot, const bool& autostart);
-
-  /**
-   * @brief full constructor
-   *
-   * @tparam ObjectType
-   * @param nh
-   * @param duration
-   * @param ObjectType::*const callback
-   * @param obj
-   * @param oneshot
-   * @param autostart
-   */
-  template <class ObjectType>
-  ThreadTimer(const ros::NodeHandle& nh, const ros::Duration& duration, void (ObjectType::*const callback)(const ros::TimerEvent& event), ObjectType* const obj,
-              const bool& oneshot, const bool& autostart);
-
-  /**
-   * @brief stop the timer
-   */
-  void stop(void);
-
-  /**
-   * @brief start the timer
-   */
-  void start(void);
-
-  /**
-   * @brief set the timer period/duration
-   *
-   * @param duration
-   * @param reset
-   */
-  void setPeriod(const ros::Duration& duration, const bool& reset = true);
-
-private:
-  class Impl;
-
-  std::shared_ptr<Impl> impl_;
-
-};  // namespace mrs_lib
-
-//}
-
-/* class ThreadTimer::Impl //{ */
-
-class ThreadTimer::Impl {
-public:
-  Impl();
-  ~Impl();
-
-  void start(void);
-  void stop(void);
-  void setPeriod(const ros::Duration& duration, const bool& reset = true);
-
-  bool          oneshot_;
-  bool          shoot_ = false;
-  ros::Rate     rate_;
-  ros::Duration duration_;
-
-  std::function<void(const ros::TimerEvent&)> callback_;
-
-private:
-  bool      running_;
-  ros::Time next_expected_;
-  ros::Time last_expected_;
-  ros::Time last_real_;
-
-  bool        thread_created_ = false;
-  std::thread thread_;
-
-  void threadFcn(void);
-
-  bool       rate_changed_ = false;
-  std::mutex mutex_time_;
-
-  // for oneshot
-
-  std::mutex              mutex_oneshot_;
-  std::condition_variable oneshot_cond_;
-  bool                    oneshot_stop_waiting_ = false;
-
-  bool       stop_oneshot_     = false;
-  bool       prolong_oneshot_  = false;
-  bool       oneshot_sleeping_ = false;
-  ros::Time  prolong_to_;
-  std::mutex mutex_prolong_;
-};
-
-//}
+  //}
 
 #include <impl/timer.hpp>
 

--- a/src/subscribe_handler/example.cpp
+++ b/src/subscribe_handler/example.cpp
@@ -60,6 +60,20 @@ int main(int argc, char **argv)
   mrs_lib::SubscribeHandlerOptions shopts(nh);
   shopts.node_name = node_name;
   shopts.threadsafe = threadsafe;
+  shopts.no_message_timeout = no_message_timeout;
+  // This is an interesting switch. It selects whether the ROS-based timer implementation for timeout checks will be used
+  // (when it's false) or a STL thread-based custom implementation is used (whe it's true).
+  //
+  // * when it's false:
+  //   You'll see that the timeout callback is only called once per each spinOnce call even though the message
+  //   timeout is long overdue (it is set to 1s and spinOnce is called every 3s). This is because timer callbacks are processed
+  //   in the spinOnce call. This can cause problems in some cases (eg. when you run out of callback threads of a nodelet
+  //   manager), so watch out!
+  //
+  // * when it's true:
+  //   Our custom timer implementation will be used. The timeout callbacks will now be called every second without messages
+  //   irregardles of the spinOnce call. This is the prefferred behavior in many cases.
+  shopts.use_thread_timer = false;
 
   /* This is how a new SubscribeHandler object is initialized. */ 
   mrs_lib::SubscribeHandler<std_msgs::String> handler(
@@ -75,22 +89,8 @@ int main(int argc, char **argv)
             shopts,
             topic_name,
             no_message_timeout,
-            /* timeout_callback, */
-            /* message_callback */
             &SubObject::timeout_method, &sub_obj,
             &SubObject::callback_method, &sub_obj
-            );
-
-  /* A variation of the factory method for easier use with objects also exists. */ 
-  mrs_lib::construct_object(
-            handler,
-            shopts,
-            topic_name,
-            no_message_timeout,
-            /* timeout_callback, */
-            /* message_callback */
-            &SubObject::callback_method, &sub_obj,
-            &SubObject::timeout_method, &sub_obj
             );
 
   /* Type of the message may be accessed by C++11 decltype in case of need */ 
@@ -98,7 +98,7 @@ int main(int argc, char **argv)
   ros::Publisher pub = nh.advertise<message_type>(topic_name, 5);
 
   /* Now let's just spin to process calbacks until the user decides to stop the program. */ 
-  ros::Rate r(2);
+  ros::Duration d(3.0);
   while (ros::ok())
   {
     message_type msg;
@@ -106,6 +106,6 @@ int main(int argc, char **argv)
     pub.publish(msg);
     ROS_INFO_THROTTLE(1.0, "[%s]: Spinning", ros::this_node::getName().c_str());
     ros::spinOnce();
-    r.sleep();
+    d.sleep();
   }
 }

--- a/test.launch
+++ b/test.launch
@@ -1,0 +1,10 @@
+<launch>
+
+  <arg name="debug" default="false" />
+  <arg unless="$(arg debug)" name="launch_prefix" value=""/>
+  <arg     if="$(arg debug)" name="launch_prefix" value="debug_roslaunch"/>
+
+  <node pkg="mrs_lib" type="subscribe_handler_example" name="subscriber_handler_example" output="screen" launch-prefix="$(arg launch_prefix)" />
+
+</launch>
+


### PR DESCRIPTION
Minor refactor of `SubscribeHandler` to enable choosing either `ROSTimer` or `ThreadTimer` for the message timeout timer. This is important e.g. for cases where the ROS callback queue gets stuck for some reason and you still need the message timeout callbacks to be called.

Also changes implementation of the `ThreadTimer` to untangle it a bit and fixes some minor bugs there.

Related issue: #28 