### PR TITLE
scope_timer: add ScopeTimerLogger and use chrono::steady_clock

### DIFF
--- a/include/mrs_lib/scope_timer.h
+++ b/include/mrs_lib/scope_timer.h
@@ -8,79 +8,146 @@
 #include <ros/ros.h>
 #include <chrono>
 #include <iostream>
+#include <fstream>
 #include <iomanip>
+#include <mutex>
 /* #include <ctime> */
 
 namespace mrs_lib
 {
 
+/*//{ ScopeTimerLogger class */
+
 /**
- * @brief simple timer which will time a duration of a scope and checkpoints inside the scope in ros time and std::chrono time
+ * @brief Simple file logger of scope timer and its checkpoints
+ */
+class ScopeTimerLogger {
+
+public:
+  /**
+   * @brief The basic constructor with a user-defined path to the logger file, enable flag and float-logging precision
+   */
+  ScopeTimerLogger(const std::string& logfile, const bool enable_logging = true, const int log_precision = 10);
+
+  /**
+   * @brief The basic destructor which closes the logging file
+   */
+  ~ScopeTimerLogger();
+
+  /**
+   * @brief Returns true if a non-empty path to a logger file was given by the user
+   */
+  bool shouldLog() {
+    return _should_log_;
+  }
+
+  /**
+   * @brief Returns true if the enable flag was set to true, a non-empty path to a logger file was given by the user and the logger file stream was successfully
+   * opened.
+   */
+  bool loggingEnabled() {
+    return _logging_enabled_;
+  }
+
+  /**
+   * @brief Returns the path to the log.
+   */
+  std::string getLogFilepath() {
+    return _log_filepath_;
+  }
+
+  using chrono_tp = std::chrono::time_point<std::chrono::steady_clock>;
+
+  /**
+   * @brief Writes the time data of the given scope and empty checkpoints into the logger stream.
+   */
+  void log(const std::string& scope, const chrono_tp& time_start, const chrono_tp& time_end);
+
+  /**
+   * @brief Writes the time data of the given scope and checkpoint labels into the logger stream.
+   */
+  void log(const std::string& scope, const std::string& label_from, const std::string& label_to, const chrono_tp& time_start, const chrono_tp& time_end);
+
+private:
+  bool          _logging_enabled_ = false;
+  bool          _should_log_      = false;
+  std::string   _log_filepath_;
+  std::ofstream _logstream_;
+  std::mutex    _mutex_logstream_;
+};
+
+/*//}*/
+
+/**
+ * @brief Simple timer which will time a duration of a scope and checkpoints inside the scope in ros time and std::chrono time.
  */
 class ScopeTimer {
 public:
   /* time_point() helper struct //{ */
   struct time_point
   {
-    using chrono_tp = std::chrono::time_point<std::chrono::system_clock>;
-  
-    public:
-      time_point(const std::string& label) :
-        ros_time(ros::Time::now()),
-        chrono_time(std::chrono::system_clock::now()),
-        label("(" + label + ")")
-      {}
-  
-      time_point(const std::string& label, const ros::Time& ros_time) :
-        ros_time(ros_time),
-        label("(" + label + ")")
-      {
-        // helper types to make the code slightly more readable
-        using float_seconds = std::chrono::duration<float>;
-        using chrono_duration = std::chrono::system_clock::duration;
-        // prepare ros and chrono current times to minimize their difference
-        const auto ros_now = ros::Time::now();
-        const auto chrono_now = std::chrono::system_clock::now();
-        // calculate how old is ros_time
-        const auto ros_dt = ros_now - ros_time;
-        // cast ros_dt to chrono type
-        const auto chrono_dt = std::chrono::duration_cast<chrono_duration>(float_seconds(ros_dt.toSec()));
-        // calculate ros_time in chrono time and set it to chrono_time
-        chrono_time = chrono_now - chrono_dt;
-      }
-  
-      ros::Time ros_time;
-      chrono_tp chrono_time;
-      std::string label;
+    using chrono_tp = std::chrono::time_point<std::chrono::steady_clock>;
+
+  public:
+    time_point(const std::string& label) : ros_time(ros::Time::now()), chrono_time(std::chrono::steady_clock::now()), label(label) {
+    }
+
+    time_point(const std::string& label, const ros::Time& ros_time) : ros_time(ros_time), label(label) {
+      // helper types to make the code slightly more readable
+      using float_seconds   = std::chrono::duration<float>;
+      using chrono_duration = std::chrono::steady_clock::duration;
+      // prepare ros and chrono current times to minimize their difference
+      const auto ros_now    = ros::Time::now();
+      const auto chrono_now = std::chrono::steady_clock::now();
+      // calculate how old is ros_time
+      const auto ros_dt = ros_now - ros_time;
+      // cast ros_dt to chrono type
+      const auto chrono_dt = std::chrono::duration_cast<chrono_duration>(float_seconds(ros_dt.toSec()));
+      // calculate ros_time in chrono time and set it to chrono_time
+      chrono_time = chrono_now - chrono_dt;
+    }
+
+    ros::Time   ros_time;
+    chrono_tp   chrono_time;
+    std::string label;
   };
   //}
 
-
 public:
   /**
-   * @brief the basic constructor with a user-defined label of the timer
+   * @brief The basic constructor with a user-defined label of the timer, throttled period and file logger.
    */
-  ScopeTimer(const std::string& label, const ros::Duration& throttle_period = ros::Duration(0));
+  ScopeTimer(const std::string& label, const ros::Duration& throttle_period = ros::Duration(0), const bool enable = true,
+             const std::shared_ptr<ScopeTimerLogger> scope_timer_logger = nullptr);
 
   /**
-   * @brief the basic constructor with a user-defined label of the timer and a pre-start time, which will also be measured
+   * @brief The basic constructor with a user-defined label of the timer and a pre-start time, which will also be measured.
    */
-  ScopeTimer(const std::string& label, const time_point& tp0, const ros::Duration& throttle_period = ros::Duration(0));
+  ScopeTimer(const std::string& label, const time_point& tp0, const ros::Duration& throttle_period = ros::Duration(0), const bool enable = true,
+             const std::shared_ptr<ScopeTimerLogger> scope_timer_logger = nullptr);
 
   /**
-   * @brief checkpoint, prints the time passed until the point this function is called
+   * @brief The basic constructor with a user-defined label of the timer and file logger.
+   */
+  ScopeTimer(const std::string& label, const std::shared_ptr<ScopeTimerLogger> scope_timer_logger, const bool enable = true);
+
+  /**
+   * @brief Checkpoint, prints the time passed until the point this function is called.
    */
   void checkpoint(const std::string& label);
 
   /**
-   * @brief the basic destructor
+   * @brief The basic destructor which prints out or logs the scope times, if enabled.
    */
   ~ScopeTimer();
 
 private:
   std::string             _timer_label_;
+  bool                    _enable_print_or_log;
   ros::Duration           _throttle_period_;
   std::vector<time_point> checkpoints;
+
+  std::shared_ptr<ScopeTimerLogger> _logger_ = nullptr;
 
   static std::unordered_map<std::string, ros::Time> last_print_times;
 };

--- a/src/scope_timer/scope_timer.cpp
+++ b/src/scope_timer/scope_timer.cpp
@@ -3,35 +3,116 @@
 namespace mrs_lib
 {
 
+// | --------------------- ScopeTimerLogger --------------------- |
+
+/*//{ ScopeTimerLogger constructor */
+ScopeTimerLogger::ScopeTimerLogger(const std::string& logfile, const bool enable_logging, const int log_precision)
+    : _logging_enabled_(enable_logging), _log_filepath_(logfile) {
+
+  if (!_logging_enabled_) {
+    return;
+  } else if (logfile.empty()) {
+    _logging_enabled_ = false;
+    ROS_INFO("[%s] ScopeTimerLogger: Logfile path not specified. Skipping logging to file.", ros::this_node::getName().c_str());
+    return;
+  }
+  _should_log_ = true;
+
+  try {
+    std::scoped_lock lock(_mutex_logstream_);
+
+    _logstream_ = std::ofstream(logfile, std::ios_base::out | std::ios_base::trunc);
+
+    if (!_logstream_.is_open()) {
+      _logging_enabled_ = false;
+      ROS_ERROR("[%s]: Scope timer failed to create log file with path (%s). Skipping logging.", ros::this_node::getName().c_str(), logfile.c_str());
+      return;
+    }
+
+    _logstream_ << std::fixed << std::setprecision(log_precision);
+    _logstream_ << "#scope,label_from,label_to,sec_start,sec_end,sec_duration" << std::endl;
+    _logging_enabled_ = true;
+  }
+  catch (...) {
+    ROS_ERROR("[%s]: Scope timer logger could not open logger file at: %s. Skipping logging.", ros::this_node::getName().c_str(), logfile.c_str());
+    return;
+  }
+
+  ROS_INFO("[%s]: Scope timer logger path: %s.", ros::this_node::getName().c_str(), logfile.c_str());
+}
+/*//}*/
+
+/*//{ ScopeTimerLogger destructor */
+ScopeTimerLogger::~ScopeTimerLogger() {
+  if (_logging_enabled_) {
+    ROS_DEBUG("[%s]: ScopeTimerLogger: closing logstream.", ros::this_node::getName().c_str());
+    _logstream_.close();
+  }
+}
+/*//}*/
+
+/*//{ ScopeTimerLogger::log() */
+void ScopeTimerLogger::log(const std::string& scope, const chrono_tp& time_start, const chrono_tp& time_end) {
+  log(scope, "", "", time_start, time_end);
+}
+
+void ScopeTimerLogger::log(const std::string& scope, const std::string& label_from, const std::string& label_to, const chrono_tp& time_start,
+                           const chrono_tp& time_end) {
+
+  if (!_logging_enabled_) {
+    return;
+  }
+
+  const std::chrono::duration<double> duration_start = std::chrono::duration_cast<std::chrono::duration<double>>(time_start.time_since_epoch());
+  const std::chrono::duration<double> duration_end   = std::chrono::duration_cast<std::chrono::duration<double>>(time_end.time_since_epoch());
+  const std::chrono::duration<double> duration_total = std::chrono::duration_cast<std::chrono::duration<double>>(time_end - time_start);
+
+  {
+    std::scoped_lock lock(_mutex_logstream_);
+    _logstream_ << scope.c_str() << "," << label_from.c_str() << "," << label_to.c_str() << "," << duration_start.count() << "," << duration_end.count() << ","
+                << duration_total.count() << std::endl;
+  }
+}
+/*//}*/
+
 // | ------------------------ ScopeTimer ------------------------ |
 
 std::unordered_map<std::string, ros::Time> ScopeTimer::last_print_times;
 
 /* ScopeTimer constructor //{ */
 
-ScopeTimer::ScopeTimer(const std::string& label, const ros::Duration& throttle_period)
-  : _timer_label_(label), _throttle_period_(throttle_period)
-{
+ScopeTimer::ScopeTimer(const std::string& label, const ros::Duration& throttle_period, const bool enable,
+                       const std::shared_ptr<ScopeTimerLogger> scope_timer_logger)
+    : _timer_label_(label), _enable_print_or_log(enable), _throttle_period_(throttle_period), _logger_(scope_timer_logger) {
+
   checkpoints.push_back(time_point("timer start"));
 
-  ROS_DEBUG("[%s]Scope timer started, label: %s", ros::this_node::getName().c_str(), label.c_str());
+  ROS_DEBUG("[%s] Scope timer started, label: %s", ros::this_node::getName().c_str(), label.c_str());
 }
 
-ScopeTimer::ScopeTimer(const std::string& label, const time_point& tp0, const ros::Duration& throttle_period)
-  : _timer_label_(label), _throttle_period_(throttle_period)
-{
+ScopeTimer::ScopeTimer(const std::string& label, const time_point& tp0, const ros::Duration& throttle_period, const bool enable,
+                       const std::shared_ptr<ScopeTimerLogger> scope_timer_logger)
+    : _timer_label_(label), _enable_print_or_log(enable), _throttle_period_(throttle_period), _logger_(scope_timer_logger) {
+
   checkpoints.push_back(tp0);
   checkpoints.push_back(time_point("timer start"));
 
-  ROS_DEBUG("[%s]Scope timer started, label: %s", ros::this_node::getName().c_str(), label.c_str());
+  ROS_DEBUG("[%s] Scope timer started with file logger (label: %s).", ros::this_node::getName().c_str(), label.c_str());
+}
+
+ScopeTimer::ScopeTimer(const std::string& label, const std::shared_ptr<ScopeTimerLogger> scope_timer_logger, const bool enable)
+    : _timer_label_(label), _enable_print_or_log(enable), _throttle_period_(ros::Duration(0.0)), _logger_(scope_timer_logger) {
+
+  checkpoints.push_back(time_point("timer start"));
+
+  ROS_DEBUG("[%s] Scope timer started with file logger (label: %s).", ros::this_node::getName().c_str(), label.c_str());
 }
 
 //}
 
-/* checkpoint() //{ */
+/* ScopeTimer::checkpoint() //{ */
 
-void ScopeTimer::checkpoint(const std::string& label)
-{
+void ScopeTimer::checkpoint(const std::string& label) {
   checkpoints.push_back(time_point(label));
 }
 
@@ -41,28 +122,27 @@ void ScopeTimer::checkpoint(const std::string& label)
 
 ScopeTimer::~ScopeTimer() {
 
-  const auto chrono_end_time = std::chrono::system_clock::now();
+  if (!_enable_print_or_log) {
+    return;
+  }
+
+  const auto chrono_end_time = std::chrono::steady_clock::now();
   const auto ros_end_time    = ros::Time::now();
 
   // if throttling is enabled, check time of last print and only print if applicable
-  if (!_throttle_period_.isZero())
-  {
-    bool do_print = false;
-    const auto last_it = last_print_times.find(_timer_label_);
+  if (!_throttle_period_.isZero()) {
+    bool       do_print = false;
+    const auto last_it  = last_print_times.find(_timer_label_);
     // if this is the first print of this ScopeTimer
-    if (last_it == last_print_times.end())
-    {
+    if (last_it == last_print_times.end()) {
       do_print = true;
       last_print_times.emplace(_timer_label_, ros_end_time);
-    }
-    else
-    {
+    } else {
       // if this ScopeTimer was already printed, check how long ago
       ros::Time& last_print_time = last_it->second;
-      if (ros_end_time - last_print_time > _throttle_period_)
-      {
+      if (ros_end_time - last_print_time > _throttle_period_) {
         // if it was long ago enough, print again and update the last print time
-        do_print = true;
+        do_print        = true;
         last_print_time = ros_end_time;
       }
     }
@@ -71,75 +151,97 @@ ScopeTimer::~ScopeTimer() {
       return;
   }
 
-  checkpoints.push_back(time_point("scope end"));
+  // If logger object exists and it should log (a path to a logger file was given by the user)
+  if (_logger_ && _logger_->shouldLog()) {
 
-  int gap1 = 8;
-  int gap2 = 8;
-  int gap3 = 12;
+    // Enabled, if user sets the enable flag to true, a path to a logger file is given, and the logging stream was successfully opened
+    if (!_logger_->loggingEnabled()) {
+      return;
+    }
 
-  std::stringstream ss;
-  ss.precision(3);
-  ss << std::fixed;
+    // Log checkpoints, e.g., "SCOPE->checkpoint1;checkpoint1->checkpoint2"
+    std::string label_from = "";
+    for (size_t i = 1; i < checkpoints.size(); i++) {
+      const auto& checkpoint = checkpoints.at(i);
+      _logger_->log(_timer_label_, label_from, checkpoint.label, checkpoints.at(i - 1).chrono_time, checkpoint.chrono_time);
+      label_from = checkpoint.label;
+    }
 
-  char separator = ' ';
+    // Log entire scope from start to end
+    _logger_->log(_timer_label_, checkpoints.at(0).chrono_time, chrono_end_time);
 
-  int max_label_width = 5;
-  for (const auto& el : checkpoints)
-  {
-    const int len = el.label.length();
-    if (len > max_label_width)
-      max_label_width = len;
-  }
+  } else {
 
-  int width_label_column = 10;
-  for (unsigned long i = 1; i < checkpoints.size(); i++) {
-    const int len = (checkpoints.at(i).label + checkpoints.at(i - 1).label).length();
-    if (len > width_label_column)
-      width_label_column = len;
-  }
-  width_label_column += 7;
+    checkpoints.push_back(time_point("scope end"));
 
-  ss << std::endl << std::left << std::setw(width_label_column) << std::setfill(separator) << " {label}";
-  ss << std::left << std::setw(gap1) << std::setfill(separator) << "";
-  ss << std::left << std::setw(gap2) << std::setfill(separator) << "{ROS time}";
-  ss << std::left << std::setw(gap3) << std::setfill(separator) << "";
-  ss << std::left << std::setw(gap2) << std::setfill(separator) << "{chrono time}" << std::endl;
+    const int gap1 = 8;
+    const int gap2 = 8;
+    const int gap3 = 12;
 
-  for (unsigned long i = 1; i < checkpoints.size(); i++) {
+    std::stringstream ss;
+    ss.precision(3);
+    ss << std::fixed;
 
-    double ros_elapsed = (checkpoints.at(i).ros_time - checkpoints.at(i - 1).ros_time).toSec();
-    int    ros_secs    = int(ros_elapsed);
-    double ros_msecs   = std::fmod(ros_elapsed * 1000, 1000);
+    const char separator = ' ';
 
-    std::chrono::duration<double> chrono_elapsed = (checkpoints.at(i).chrono_time - checkpoints.at(i - 1).chrono_time);
-    int                           chrono_secs    = int(chrono_elapsed.count());
-    double                        chrono_msecs   = std::fmod(chrono_elapsed.count() * 1000, 1000);
+    int max_label_width = 5;
+    for (auto& el : checkpoints) {
+      el.label      = "(" + el.label + ")";
+      const int len = el.label.length();
+      if (len > max_label_width)
+        max_label_width = len;
+    }
 
-    ss << std::left << std::setw(max_label_width) << std::setfill(separator) << checkpoints.at(i - 1).label;
-    ss << " -> ";
-    ss << std::left << std::setw(max_label_width) << std::setfill(separator) << checkpoints.at(i).label;
+    int width_label_column = 10;
+    for (unsigned long i = 1; i < checkpoints.size(); i++) {
+      const int len = (checkpoints.at(i).label + checkpoints.at(i - 1).label).length();
+      if (len > width_label_column)
+        width_label_column = len;
+    }
+    width_label_column += 7;
 
+    ss << std::endl << std::left << std::setw(width_label_column) << std::setfill(separator) << " {label}";
+    ss << std::left << std::setw(gap1) << std::setfill(separator) << "";
+    ss << std::left << std::setw(gap2) << std::setfill(separator) << "{ROS time}";
+    ss << std::left << std::setw(gap3) << std::setfill(separator) << "";
+    ss << std::left << std::setw(gap2) << std::setfill(separator) << "{chrono time}" << std::endl;
+
+    for (unsigned long i = 1; i < checkpoints.size(); i++) {
+
+      const double ros_elapsed = (checkpoints.at(i).ros_time - checkpoints.at(i - 1).ros_time).toSec();
+      const int    ros_secs    = int(ros_elapsed);
+      const double ros_msecs   = std::fmod(ros_elapsed * 1000, 1000);
+
+      const std::chrono::duration<double> chrono_elapsed = (checkpoints.at(i).chrono_time - checkpoints.at(i - 1).chrono_time);
+      const int                           chrono_secs    = int(chrono_elapsed.count());
+      const double                        chrono_msecs   = std::fmod(chrono_elapsed.count() * 1000, 1000);
+
+      ss << std::left << std::setw(max_label_width) << std::setfill(separator) << checkpoints.at(i - 1).label;
+      ss << " -> ";
+      ss << std::left << std::setw(max_label_width) << std::setfill(separator) << checkpoints.at(i).label;
+
+      ss << std::right << std::setw(gap1) << std::setfill(separator) << ros_secs << std::setw(0) << "s";
+      ss << std::right << std::setw(gap2) << std::setfill(separator) << ros_msecs << std::setw(0) << "ms";
+      ss << std::right << std::setw(gap3) << std::setfill(separator) << chrono_secs << std::setw(0) << "s";
+      ss << std::right << std::setw(gap2) << std::setfill(separator) << chrono_msecs << std::setw(0) << "ms" << std::endl;
+    }
+
+    const double ros_elapsed = (ros_end_time - checkpoints.at(0).ros_time).toSec();
+    const int    ros_secs    = int(ros_elapsed);
+    const double ros_msecs   = std::fmod(ros_elapsed * 1000, 1000);
+
+    const std::chrono::duration<double> chrono_elapsed = (chrono_end_time - checkpoints.at(0).chrono_time);
+    const int                           chrono_secs    = int(chrono_elapsed.count());
+    const double                        chrono_msecs   = std::fmod(chrono_elapsed.count() * 1000, 1000);
+
+    ss << std::left << std::setw(width_label_column) << std::setfill(separator) << "TOTAL TIME";
     ss << std::right << std::setw(gap1) << std::setfill(separator) << ros_secs << std::setw(0) << "s";
     ss << std::right << std::setw(gap2) << std::setfill(separator) << ros_msecs << std::setw(0) << "ms";
     ss << std::right << std::setw(gap3) << std::setfill(separator) << chrono_secs << std::setw(0) << "s";
     ss << std::right << std::setw(gap2) << std::setfill(separator) << chrono_msecs << std::setw(0) << "ms" << std::endl;
+
+    ROS_INFO("[%s]: Scope timer [%s] finished!%s", ros::this_node::getName().c_str(), _timer_label_.c_str(), ss.str().c_str());
   }
-
-  double ros_elapsed = (ros_end_time - checkpoints.at(0).ros_time).toSec();
-  int    ros_secs    = int(ros_elapsed);
-  double ros_msecs   = std::fmod(ros_elapsed * 1000, 1000);
-
-  std::chrono::duration<double> chrono_elapsed = (chrono_end_time - checkpoints.at(0).chrono_time);
-  int                           chrono_secs    = int(chrono_elapsed.count());
-  double                        chrono_msecs   = std::fmod(chrono_elapsed.count() * 1000, 1000);
-
-  ss << std::left << std::setw(width_label_column) << std::setfill(separator) << "TOTAL TIME";
-  ss << std::right << std::setw(gap1) << std::setfill(separator) << ros_secs << std::setw(0) << "s";
-  ss << std::right << std::setw(gap2) << std::setfill(separator) << ros_msecs << std::setw(0) << "ms";
-  ss << std::right << std::setw(gap3) << std::setfill(separator) << chrono_secs << std::setw(0) << "s";
-  ss << std::right << std::setw(gap2) << std::setfill(separator) << chrono_msecs << std::setw(0) << "ms" << std::endl;
-
-  ROS_INFO("[%s]: Scope timer [%s] finished!%s", ros::this_node::getName().c_str(), _timer_label_.c_str(), ss.str().c_str());
 }
 
 //}


### PR DESCRIPTION
Three changes to `scope_timer`:

1) Instead of `chrono::system_clock`, it now uses [`chrono::steady_clock`](https://en.cppreference.com/w/cpp/chrono/steady_clock) which is more appropriate for measuring time intervals (guarantees monotonicity and a constant time between ticks).
2) Scope timer can now be [disabled](https://github.com/ctu-mrs/mrs_lib/commit/e7ee0e013bb637a2a499f0332cc3b9e2ead905fa#diff-f81b22af0567d6f172940fe9c0dbbaa03fac7c2625e3489ea672e28b37fb3988R120-R121 ) if needed to prevent spamming to the terminal. Similarly, as we do in [`profiler`](https://github.com/ctu-mrs/mrs_lib/blob/master/include/mrs_lib/profiler.h#L18-L19). Example of using a bool flag `enable_scope_timer`:
```cpp
{
 mrs_lib::ScopeTimer timer = mrs_lib::ScopeTimer("ExampleScope", enable_scope_timer);
 ...
}
````

3) [`ScopeTimerLogger`](https://github.com/ctu-mrs/mrs_lib/commit/e7ee0e013bb637a2a499f0332cc3b9e2ead905fa#diff-f81b22af0567d6f172940fe9c0dbbaa03fac7c2625e3489ea672e28b37fb3988R24-R77) class is introduced. A shared pointer of `mrs_lib::ScopeTimerLogger` can be given to a `mrs_lib::ScopeTimer` if the measurements shall be logged into a log file ([format](https://github.com/ctu-mrs/mrs_lib/commit/e7ee0e013bb637a2a499f0332cc3b9e2ead905fa#diff-10735cb252efbc1f57141578ca51138ffdce94f24d36ec388bc38a66ba5f6cf1R33)). 

   The `mrs_lib::ScopeTimer` **will log into a file and will not print to terminal**, if `enable_scope_timer` is `true` and the given `std::shared_ptr<mrs_lib::ScopeTimerLogger>`
   - is initialized,
   - its [`enable_logging`](https://github.com/ctu-mrs/mrs_lib/commit/e7ee0e013bb637a2a499f0332cc3b9e2ead905fa#diff-f81b22af0567d6f172940fe9c0dbbaa03fac7c2625e3489ea672e28b37fb3988R30) flag is set to true, and
   - the [`logfile`](https://github.com/ctu-mrs/mrs_lib/commit/e7ee0e013bb637a2a499f0332cc3b9e2ead905fa#diff-f81b22af0567d6f172940fe9c0dbbaa03fac7c2625e3489ea672e28b37fb3988R30) stream could be successfully opened for logging.

   The `mrs_lib::ScopeTimer` **will not log into a file and will print to terminal**, if `enable_scope_timer` is `true` and the given `std::shared_ptr<mrs_lib::ScopeTimerLogger>`
   - is uninitialized (is `nullptr`) or
   - is initialized and `logfile` path string is empty (equals `""`).
   
   The `mrs_lib::ScopeTimer` **will not log into a file nor will print to terminal**, if `enable_scope_timer` is `false` or the given `std::shared_ptr<mrs_lib::ScopeTimerLogger>`
   - is initialized, but the non-empty string `logfile` could not open output stream for logging.
   
### Logs processing
Example processing analysis of the logs is available in [`uav_core/miscellaneous/scope_timer_viewer`](https://github.com/ctu-mrs/uav_core/blob/master/miscellaneous/scope_timer_viewer/scope_timer_viewer.py). Run `./scope_timer_viewer.py -h` to see what it can do (processing single logs and logs directories, as well as comparing two logs or logs of directories). Example output of the current processing script (work in progress) comparing two logs directories:
```bash
A: first logsdir
B: second logsdir
PCLFiltration::process_depth_msg::down_rgbd | from:  | to:
   A -> mean: 1.6 ms | mean: 100.0% | std: 1.5 ms | std: 100.0%
   B -> mean: 2.0 ms | mean: 121.2% | std: 1.5 ms | std: 99.2%
Odometry::mainTimer | from:  | to:
   A -> mean: 0.4 ms | mean: 100.0% | std: 0.1 ms | std: 100.0%
   B -> mean: 0.4 ms | mean: 104.2% | std: 2.1 ms | std: 1823.7%
OctomapServer::insertAerialCloudCallback::ouster | from:  | to:
   A -> mean: 59.0 ms | mean: 100.0% | std: 36.3 ms | std: 100.0%
   B -> mean: 43.9 ms | mean: 74.4% | std: 21.7 ms | std: 59.9%
```
   
### Example initialization of the `mrs_lib::ScopeTimerLogger` in the member variable context.

   **Header:**
   ```cpp
   bool _enable_scope_timer_ = true;
   bool _enable_scope_timer_logger_ = true;
   std::shared_ptr<mrs_lib::ScopeTimerLogger> _scope_timer_logger_;
   ```

   **Runtime initialization of member variables:**
   ```cpp
   _scope_timer_logger_ = std::make_shared<mrs_lib::ScopeTimerLogger>("/tmp/scope_timer_example.log", 
   _enable_scope_timer_logger_);
   ```

   **Runtime usage of scope timer:**
   ```cpp
   {
   mrs_lib::ScopeTimer timer = mrs_lib::ScopeTimer("ExampleScope", _scope_timer_logger_, _enable_scope_timer_);
   ...
   timer.checkpoint("A");
   ...
   timer.checkpoint("B");
   ...
   }
   ```
   **Produced `.log` (`"/tmp/scope_timer_example.log"`) :**
   ```bash
   #scope,label_from,label_to,sec_start,sec_end,sec_duration
   ExampleScope,,A,t0,t1,t1-t0
   ExampleScope,A,B,t1,t2,t2-t1
   ExampleScope,,,t0,t3,t3-t0
   ```
