### PR TITLE
adding transformer for Eigen::Vector3d

### DIFF
--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -49,7 +49,7 @@ namespace tf2
     cloud_out.header.frame_id = transform.header.frame_id;
   }
 
-}
+}  // namespace tf2
 
 namespace mrs_lib
 {

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -351,6 +351,7 @@ namespace mrs_lib
     std::optional<mrs_msgs::ReferenceStamped> transformImpl(const mrs_lib::TransformStamped& tf, const mrs_msgs::ReferenceStamped& what);
     std::optional<geometry_msgs::PoseStamped> transformImpl(const mrs_lib::TransformStamped& tf, const geometry_msgs::PoseStamped& what);
     std::optional<geometry_msgs::Point> transformImpl(const mrs_lib::TransformStamped& tf, const geometry_msgs::Point& what);
+    std::optional<Eigen::Vector3d> transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::Vector3d& what);
     /* std::optional<Eigen::MatrixXd> transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what); */
     /* std::optional<Eigen::MatrixXd> transformMat2(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what); */
     /* std::optional<Eigen::MatrixXd> transformMat3(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what); */

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -44,7 +44,9 @@ namespace mrs_lib
     this->is_initialized_ = true;
   }
 
-  Transformer::Transformer(const std::string& node_name) : Transformer(node_name, ""){}
+  Transformer::Transformer(const std::string& node_name) : Transformer(node_name, "")
+  {
+  }
 
   Transformer::Transformer(const Transformer& other)
   {
@@ -255,7 +257,7 @@ namespace mrs_lib
 
   std::optional<Eigen::Vector3d> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::Vector3d& what)
   {
-    const Eigen::Vector3d output = tf.getTransformEigen().rotation()*what;
+    const Eigen::Vector3d output = tf.getTransformEigen().rotation() * what;
     return output;
   }
 
@@ -305,10 +307,10 @@ namespace mrs_lib
 
       {
         const auto pose_opt = doTransform(start_to_utm_origin_tf_opt.value(), ret);
-        
+
         if (!pose_opt.has_value())
           return std::nullopt;
-        
+
         ret = std::move(pose_opt.value());
       }
 
@@ -378,10 +380,10 @@ namespace mrs_lib
 
       {
         const auto pose_opt = doTransform(start_to_utm_origin_tf_opt.value(), ret);
-        
+
         if (!pose_opt.has_value())
           return std::nullopt;
-        
+
         ret = std::move(pose_opt.value());
       }
 
@@ -571,11 +573,12 @@ namespace mrs_lib
 
         return in;
       }
-    } 
+    }
     /* else */
     /* { */
 
-    /*   ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: could not deduce a namespaced frame_id '%s' (did you instance the Transformer with the uav_name argument?)", */
+    /*   ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: could not deduce a namespaced frame_id '%s' (did you instance the Transformer with the uav_name argument?)",
+     */
     /*                     node_name_.c_str(), in.c_str()); */
     /* } */
 

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -253,6 +253,12 @@ namespace mrs_lib
       return std::nullopt;
   }
 
+  std::optional<Eigen::Vector3d> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::Vector3d& what)
+  {
+    const Eigen::Vector3d output = tf.getTransformEigen().rotation()*what;
+    return output;
+  }
+
   std::optional<geometry_msgs::PoseStamped> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const geometry_msgs::PoseStamped& what)
   {
     geometry_msgs::PoseStamped ret = what;

--- a/test/transformer/test.cpp
+++ b/test/transformer/test.cpp
@@ -72,6 +72,65 @@ TEST(TESTSuite, main_test) {
 
 //}
 
+/* TEST(TESTSuite, eigen_vector3d_test) //{ */
+
+TEST(TESTSuite, eigen_vector3d_test) {
+
+  ROS_INFO("[%s]: Testing the Eigen::Vector3d transformation", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("TransformerTest", "uav1");
+
+  std::optional<mrs_lib::TransformStamped> tf_opt;
+
+  // get the transform
+  for (int it = 0; it < 1000 && ros::ok(); it++) {
+
+    tf_opt = tfr.getTransform("camera", "fcu");
+
+    if (tf_opt.has_value()) {
+      break;
+    }
+
+    ros::Duration(0.1).sleep();
+  }
+
+  if (tf_opt.has_value()) {
+
+    ROS_INFO("[%s]: got the transform", ros::this_node::getName().c_str());
+
+    auto tf = tf_opt.value();
+    std::cout << "from: " << tf.from() << ", to: " << tf.to() << ", stamp: " << tf.stamp() << std::endl;
+    std::cout << tf.getTransform() << std::endl;
+
+    std::vector<std::pair<Eigen::Vector3d,Eigen::Vector3d>> test_vectors = {{{1,0,0},{0,-1,0}},{{0,1,0},{0,0,-1}},{{0,0,1},{1,0,0}}};
+
+    for (auto& tv : test_vectors){
+      auto rv = tfr.transformHeaderless(tf,tv.first);
+      if (!rv){
+        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv.first.transpose() << "]" );
+        result *= 0;
+      }
+      else {
+        Eigen::Vector3d vect_diff = rv.value() - tv.second;
+        if (vect_diff.norm() > 1e-6) {
+        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated vector [" << tv.first.transpose() << "] with value of [" << rv.value().transpose() << "] does not match the expected value of [" << tv.second.transpose() << "]");
+          result *= 0;
+        }
+      }
+    }
+
+  } else {
+    ROS_ERROR_THROTTLE(1.0, "[%s]: missing tf", ros::this_node::getName().c_str());
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
 int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
 
   // Set up ROS.

--- a/test/transformer/test.cpp
+++ b/test/transformer/test.cpp
@@ -104,18 +104,18 @@ TEST(TESTSuite, eigen_vector3d_test) {
     std::cout << "from: " << tf.from() << ", to: " << tf.to() << ", stamp: " << tf.stamp() << std::endl;
     std::cout << tf.getTransform() << std::endl;
 
-    std::vector<std::pair<Eigen::Vector3d,Eigen::Vector3d>> test_vectors = {{{1,0,0},{0,-1,0}},{{0,1,0},{0,0,-1}},{{0,0,1},{1,0,0}}};
+    std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> test_vectors = {{{1, 0, 0}, {0, -1, 0}}, {{0, 1, 0}, {0, 0, -1}}, {{0, 0, 1}, {1, 0, 0}}};
 
-    for (auto& tv : test_vectors){
-      auto rv = tfr.transformHeaderless(tf,tv.first);
-      if (!rv){
-        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv.first.transpose() << "]" );
+    for (auto& tv : test_vectors) {
+      auto rv = tfr.transformHeaderless(tf, tv.first);
+      if (!rv) {
+        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv.first.transpose() << "]");
         result *= 0;
-      }
-      else {
+      } else {
         Eigen::Vector3d vect_diff = rv.value() - tv.second;
         if (vect_diff.norm() > 1e-6) {
-        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated vector [" << tv.first.transpose() << "] with value of [" << rv.value().transpose() << "] does not match the expected value of [" << tv.second.transpose() << "]");
+          ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated vector [" << tv.first.transpose() << "] with value of ["
+                                             << rv.value().transpose() << "] does not match the expected value of [" << tv.second.transpose() << "]");
           result *= 0;
         }
       }

--- a/test/transformer/transformer.test
+++ b/test/transformer/transformer.test
@@ -2,6 +2,8 @@
 
   <node pkg="tf2_ros" type="static_transform_publisher" name="tf_publisher" args="1.0 2.0 3.0 1 1.57 2 uav1/local_origin uav1/fcu" />
 
+  <node pkg="tf2_ros" type="static_transform_publisher" name="tf_optframe_publisher" args="1.0 2.0 3.0 -0.5 0.5 -0.5 0.5 uav1/fcu uav1/camera" />
+
   <test pkg="mrs_lib" type="TransformerTest" test-name="transfomer_test" time-limit="10.0">
   </test>
 


### PR DESCRIPTION
Useful for convenient transformation of directional vectors from Eigen lib. Not intended for transforming points. Only implemented for `transformHeaderless`. 