### PR TITLE
`mrs_lib::Transformer` API update

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,7 @@ if(CATKIN_ENABLE_TESTING)
     TransformerTest
     test/transformer/transformer.test
     test/transformer/test.cpp
+    src/transform_broadcaster/transform_broadcaster.cpp
   )
 
   target_link_libraries(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,13 @@ target_include_directories(MrsLibTransformer PRIVATE
   ${PCL_INCLUDE_DIRS}
   )
 
+add_executable(transformer_example src/transformer/example.cpp)
+target_link_libraries(transformer_example
+  MrsLibTransformer
+  ${catkin_LIBRARIES}
+  ${Eigen_LIBRARIES}
+  )
+
 add_library(MrsLibUtils src/utils/utils.cpp)
 target_link_libraries(MrsLibUtils
   ${catkin_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ target_link_libraries(MrsLibAttitudeConverter
 
 add_library(MrsLibTransformer src/transformer/transformer.cpp)
 target_link_libraries(MrsLibTransformer
-  MrsLibAttitudeConverter
+  MrsLibGeometry
   ${catkin_LIBRARIES}
   ${Eigen_LIBRARIES}
   )
@@ -376,13 +376,12 @@ if(CATKIN_ENABLE_TESTING)
     TransformerTest
     test/transformer/transformer.test
     test/transformer/test.cpp
-    src/transform_broadcaster/transform_broadcaster.cpp
   )
 
   target_link_libraries(
     TransformerTest
     MrsLibTransformer
-    MrsLibAttitudeConverter
+    MrsLibGeometry
     ${catkin_LIBRARIES}
   )
 

--- a/include/impl/transformer.hpp
+++ b/include/impl/transformer.hpp
@@ -93,7 +93,7 @@ std::optional<T> Transformer::transformImpl(const geometry_msgs::TransformStampe
     // by default, transformation from/to LATLON is undefined, so return nullopt if it's attempted
     if (from_frame == latlon_frame_name || to_frame == latlon_frame_name)
     {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform message of this type to/from latitude/longitude coordinates!", ros::this_node::getName().c_str());
+      ROS_ERROR_STREAM_THROTTLE(1.0, "[" << node_name_ << "]: Transformer: cannot transform message of this type (" << typeid(T).name() << ") to/from latitude/longitude coordinates!");
       return std::nullopt;
     }
   }

--- a/include/impl/transformer.hpp
+++ b/include/impl/transformer.hpp
@@ -118,7 +118,7 @@ std::optional<T> Transformer::transformSingle(const std::string& from_frame_raw,
 {
   if (!initialized_)
   {
-    ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform, not initialized", ros::this_node::getName().c_str());
+    ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform, not initialized", node_name_.c_str());
     return std::nullopt;
   }
 
@@ -145,7 +145,7 @@ std::optional<T> Transformer::transform(const T& what, const geometry_msgs::Tran
 {
   if (!initialized_)
   {
-    ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform, not initialized", ros::this_node::getName().c_str());
+    ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform, not initialized", node_name_.c_str());
     return std::nullopt;
   }
 

--- a/include/impl/transformer.hpp
+++ b/include/impl/transformer.hpp
@@ -69,7 +69,7 @@ std::optional<T> Transformer::transformImpl(const geometry_msgs::TransformStampe
 
   // First, check if the transformation is from/to the latlon frame
   // if conversion between UVM and LatLon coordinates is defined for this message, it may be resolved
-  if constexpr (UTMLL_exists_v<T>)
+  if constexpr (UTMLL_exists_v<Transformer, T>)
   {
     // check for transformation from LAT-LON GPS
     if (from_frame == latlon_frame_name)

--- a/include/impl/transformer.hpp
+++ b/include/impl/transformer.hpp
@@ -6,13 +6,13 @@
 /* getHeader() overloads for different message types (pointers, pointclouds etc) //{ */
 
 template <typename msg_t>
-std_msgs::Header getHeader(const msg_t& msg)
+std_msgs::Header Transformer::getHeader(const msg_t& msg)
 {
   return msg.header;
 }
 
 template <typename pt_t>
-std_msgs::Header getHeader(const pcl::PointCloud<pt_t>& cloud)
+std_msgs::Header Transformer::getHeader(const pcl::PointCloud<pt_t>& cloud)
 {
   std_msgs::Header ret;
   pcl_conversions::fromPCL(cloud.header, ret);
@@ -24,13 +24,13 @@ std_msgs::Header getHeader(const pcl::PointCloud<pt_t>& cloud)
 /* setHeader() overloads for different message types (pointers, pointclouds etc) //{ */
 
 template <typename msg_t>
-void setHeader(msg_t& msg, const std_msgs::Header& header)
+void Transformer::setHeader(msg_t& msg, const std_msgs::Header& header)
 {
   msg.header = header;
 }
 
 template <typename pt_t>
-void setHeader(pcl::PointCloud<pt_t>& cloud, const std_msgs::Header& header)
+void Transformer::setHeader(pcl::PointCloud<pt_t>& cloud, const std_msgs::Header& header)
 {
   pcl_conversions::toPCL(header, cloud.header);
 }
@@ -39,26 +39,11 @@ void setHeader(pcl::PointCloud<pt_t>& cloud, const std_msgs::Header& header)
 
 /* copyChangeFrame() helper function //{ */
 
-namespace impl
-{
-  template<typename T>
-  using _has_header_member_chk = decltype( std::declval<T&>().header );
-  template<typename T>
-  constexpr bool has_header_member_v = std::experimental::is_detected<_has_header_member_chk, T>::value;
-
-  template<typename T>
-  using _UTMLL_method_chk = decltype(Transformer().UTMtoLL(std::declval<const T&>(), ""));
-  template<typename T>
-  using _LLUTM_method_chk = decltype(Transformer().LLtoUTM(std::declval<const T&>(), ""));
-  template<typename T>
-  constexpr bool UTMLL_exists_v = std::experimental::is_detected<_UTMLL_method_chk, T>::value && std::experimental::is_detected<_LLUTM_method_chk, T>::value;
-}
-
 template <typename T>
-T copyChangeFrame(const T& what, const std::string& frame_id)
+T Transformer::copyChangeFrame(const T& what, const std::string& frame_id)
 {
   T ret = what;
-  if constexpr (impl::has_header_member_v<T>)
+  if constexpr (has_header_member_v<T>)
   {
     std_msgs::Header new_header = getHeader(what);
     new_header.frame_id = frame_id;
@@ -80,34 +65,41 @@ std::optional<T> Transformer::transformImpl(const geometry_msgs::TransformStampe
   if (from_frame == to_frame)
     return copyChangeFrame(what, from_frame);
 
-  std::string latlon_frame_name = resolveFrame(LATLON_ORIGIN);
+  const std::string latlon_frame_name = resolveFrame(LATLON_ORIGIN);
 
-  std::optional<T> tmp = what;
-  // if conversion between UVM and LatLon coordinates is defined for this message, check for it
-  if constexpr (impl::UTMLL_exists_v<T>)
+  // First, check if the transformation is from/to the latlon frame
+  // if conversion between UVM and LatLon coordinates is defined for this message, it may be resolved
+  if constexpr (UTMLL_exists_v<T>)
   {
     // check for transformation from LAT-LON GPS
     if (from_frame == latlon_frame_name)
-      tmp = UTMtoLL(what, getFramePrefix(from_frame));
+    {
+      const std::optional<T> tmp = LLtoUTM(what, getFramePrefix(from_frame));
+      if (!tmp.has_value())
+        return std::nullopt;
+      return doTransform(tmp.value(), tf);
+    }
     // check for transformation to LAT-LON GPS
     else if (to_frame == latlon_frame_name)
-      tmp = LLtoUTM(what, getFramePrefix(to_frame));
+    {
+      const std::optional<T> tmp = doTransform(what, tf);
+      if (!tmp.has_value())
+        return std::nullopt;
+      return UTMtoLL(tmp.value(), getFramePrefix(to_frame));
+    }
   }
   else
   {
     // by default, transformation from/to LATLON is undefined, so return nullopt if it's attempted
     if (from_frame == latlon_frame_name || to_frame == latlon_frame_name)
     {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform message of this type to/from latitude/longtitude coordinates!", ros::this_node::getName().c_str());
+      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform message of this type to/from latitude/longitude coordinates!", ros::this_node::getName().c_str());
       return std::nullopt;
     }
   }
 
-  // this happens if UTMtoLL or LLtoUTM fails
-  if (!tmp.has_value())
-    return std::nullopt;
-
-  return doTransform(tf, what);
+  // otherwise it's just an ol' borin' transformation
+  return doTransform(what, tf);
 }
 
 //}
@@ -115,7 +107,14 @@ std::optional<T> Transformer::transformImpl(const geometry_msgs::TransformStampe
 /* transformSingle() //{ */
 
 template <class T>
-std::optional<T> Transformer::transformSingle(const std::string& to_frame_raw, const T& what)
+std::optional<T> Transformer::transformSingle(const T& what, const std::string& to_frame_raw)
+{
+  const std_msgs::Header orig_header = getHeader(what);
+  return transformSingle(orig_header.frame_id, what, to_frame_raw, orig_header.stamp);
+}
+
+template <class T>
+std::optional<T> Transformer::transformSingle(const std::string& from_frame_raw, const T& what, const std::string& to_frame_raw, const ros::Time& time_stamp)
 {
   if (!initialized_)
   {
@@ -123,18 +122,17 @@ std::optional<T> Transformer::transformSingle(const std::string& to_frame_raw, c
     return std::nullopt;
   }
 
-  const std_msgs::Header orig_header = getHeader(what);
-  const std::string from_frame = resolveFrame(orig_header.frame_id);
+  const std::string from_frame = resolveFrame(from_frame_raw);
   const std::string to_frame = resolveFrame(to_frame_raw);
 
   // get the transform
-  const auto tf_opt = getTransform(from_frame, to_frame, orig_header.stamp);
+  const auto tf_opt = getTransform(from_frame, to_frame, time_stamp);
   if (!tf_opt.has_value())
     return std::nullopt;
   const geometry_msgs::TransformStamped& tf = tf_opt.value();
 
   // do the transformation
-  const auto result_opt = transform(tf, what);
+  const auto result_opt = transform(what, tf);
   return result_opt;
 }
 
@@ -143,7 +141,7 @@ std::optional<T> Transformer::transformSingle(const std::string& to_frame_raw, c
 /* transform() //{ */
 
 template <class T>
-std::optional<T> Transformer::transform(const geometry_msgs::TransformStamped& tf, const T& what)
+std::optional<T> Transformer::transform(const T& what, const geometry_msgs::TransformStamped& tf)
 {
   if (!initialized_)
   {
@@ -163,7 +161,7 @@ std::optional<T> Transformer::transform(const geometry_msgs::TransformStamped& t
 /* doTransform() //{ */
 
 template <class T>
-std::optional<T> Transformer::doTransform(const geometry_msgs::TransformStamped& tf, const T& what)
+std::optional<T> Transformer::doTransform(const T& what, const geometry_msgs::TransformStamped& tf)
 {
   try
   {

--- a/include/mrs_lib/geometry/conversions.h
+++ b/include/mrs_lib/geometry/conversions.h
@@ -20,6 +20,11 @@ namespace mrs_lib
       return {what.x, what.y, what.z};
     }
 
+    Eigen::Vector3d toEigen(const geometry_msgs::Vector3& what)
+    {
+      return {what.x, what.y, what.z};
+    }
+
     geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what)
     {
       geometry_msgs::Quaternion q;

--- a/include/mrs_lib/geometry/conversions.h
+++ b/include/mrs_lib/geometry/conversions.h
@@ -1,22 +1,47 @@
+#ifndef GEOMETRY_CONVERSIONS_H
+#define GEOMETRY_CONVERSIONS_H
 
-
-  std::string from(const geometry_msgs::TransformStamped& msg)
+namespace mrs_lib
+{
+  namespace geometry
   {
-    return msg.header.frame_id;
-  }
 
-  std::string to(const geometry_msgs::TransformStamped& msg)
-  {
-    return msg.child_frame_id;
-  }
+    geometry_msgs::Point fromEigen(const Eigen::Vector3d& what)
+    {
+      geometry_msgs::Point pt;
+      pt.x = what.x();
+      pt.y = what.y();
+      pt.z = what.z();
+      return pt;
+    }
 
-  geometry_msgs::TransformStamped inverse(const geometry_msgs::TransformStamped& msg)
-  {
-    geometry_msgs::TransformStamped tf = transform_stamped_;
-    tf2::Transform tf2;
-    tf2::fromMsg(tf.transform, tf2);
-    tf2 = tf2.inverse();
-    tf.transform = tf2::toMsg(tf2);
-    std::swap(tf.header.frame_id, tf.child_frame_id);
-    return tf;
+    Eigen::Vector3d toEigen(const geometry_msgs::Point& what)
+    {
+      return {what.x, what.y, what.z};
+    }
+
+    geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what)
+    {
+      geometry_msgs::Quaternion q;
+      q.x = what.x();
+      q.y = what.y();
+      q.z = what.z();
+      q.w = what.w();
+      return q;
+    }
+
+    Eigen::Quaterniond toEigen(const geometry_msgs::Quaternion& what)
+    {
+      // better to do this manually than through the constructor to avoid ambiguities (e.g. position of x and w)
+      Eigen::Quaterniond q;
+      q.x() = what.x;
+      q.y() = what.y;
+      q.z() = what.z;
+      q.w() = what.w;
+      return q;
+    }
+
   }
+}
+
+#endif // GEOMETRY_CONVERSIONS_H

--- a/include/mrs_lib/geometry/conversions.h
+++ b/include/mrs_lib/geometry/conversions.h
@@ -1,0 +1,22 @@
+
+
+  std::string from(const geometry_msgs::TransformStamped& msg)
+  {
+    return msg.header.frame_id;
+  }
+
+  std::string to(const geometry_msgs::TransformStamped& msg)
+  {
+    return msg.child_frame_id;
+  }
+
+  geometry_msgs::TransformStamped inverse(const geometry_msgs::TransformStamped& msg)
+  {
+    geometry_msgs::TransformStamped tf = transform_stamped_;
+    tf2::Transform tf2;
+    tf2::fromMsg(tf.transform, tf2);
+    tf2 = tf2.inverse();
+    tf.transform = tf2::toMsg(tf2);
+    std::swap(tf.header.frame_id, tf.child_frame_id);
+    return tf;
+  }

--- a/include/mrs_lib/geometry/misc.h
+++ b/include/mrs_lib/geometry/misc.h
@@ -296,14 +296,6 @@ namespace mrs_lib
 
     //}
 
-    // | ------------------ Conversion functions ------------------ |
-
-    geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what);
-    geometry_msgs::Point fromEigen(const Eigen::Vector3d& what);
-    
-    Eigen::Vector3d toEigen(const geometry_msgs::Point& what);
-    Eigen::Quaterniond toEigen(const geometry_msgs::Quaternion& what);
-
   }  // namespace geometry
 }  // namespace mrs_lib
 

--- a/include/mrs_lib/geometry/misc.h
+++ b/include/mrs_lib/geometry/misc.h
@@ -10,6 +10,8 @@
 
 #include <cmath>
 #include <Eigen/Dense>
+#include <geometry_msgs/Point.h>
+#include <geometry_msgs/Quaternion.h>
 
 namespace mrs_lib
 {
@@ -23,6 +25,9 @@ namespace mrs_lib
     using pt3_t = vec_t<3>;
     using vec3_t = vec_t<3>;
 
+    using quat_t = Eigen::Quaterniond;
+    using anax_t = Eigen::AngleAxisd;
+
     template <int dims>
     vec_t<dims + 1> toHomogenous(const vec_t<dims>& vec)
     {
@@ -33,6 +38,22 @@ namespace mrs_lib
     // | ----------------- Angle-related functions ---------------- |
 
     /* angle-related functions //{ */
+
+    /* headingFromRot() //{ */
+
+    /*!
+     * \brief Returns the heading angle from the rotation.
+     *
+     * Heading is defined as the angle of a [1,0,0] vector rotated by the rotation and projected to the XY plane from the X axis.
+     *
+     * \param rot the rotation to extract the heading angle from.
+     *
+     * \returns the heading angle.
+     *
+     */
+    double headingFromRot(const quat_t& rot);
+
+    //}
 
     /* angleBetween() //{ */
 
@@ -81,7 +102,7 @@ namespace mrs_lib
      * \returns    rotation from \p a to \p b.
      *
      */
-    Eigen::AngleAxisd angleaxisBetween(const vec3_t& a, const vec3_t& b, const double tolerance = 1e-9);
+    anax_t angleaxisBetween(const vec3_t& a, const vec3_t& b, const double tolerance = 1e-9);
 
     //}
 
@@ -98,7 +119,7 @@ namespace mrs_lib
      * \returns    rotation from \p a to \p b.
      *
      */
-    Eigen::Quaterniond quaternionBetween(const vec3_t& a, const vec3_t& b, const double tolerance = 1e-9);
+    quat_t quaternionBetween(const vec3_t& a, const vec3_t& b, const double tolerance = 1e-9);
 
     //}
 
@@ -171,7 +192,7 @@ namespace mrs_lib
      *
      * @return quaternion
      */
-    Eigen::Quaterniond quaternionFromEuler(double x, double y, double z);
+    quat_t quaternionFromEuler(double x, double y, double z);
 
     /**
      * @brief create a quaternion from Euler angles provided as a vector
@@ -180,9 +201,20 @@ namespace mrs_lib
      *
      * @return quaternion
      */
-    Eigen::Quaterniond quaternionFromEuler(Eigen::Vector3d euler);
+    quat_t quaternionFromEuler(const Eigen::Vector3d& euler);
 
     //}
+
+    /**
+     * @brief create a quaternion from heading
+     *
+     * Heading is defined as the angle of a [1,0,0] vector rotated by the rotation and projected to the XY plane from the X axis.
+     *
+     * @param heading the heading angle.
+     *
+     * @return the quaternion corresponding to the heading rotation.
+     */
+    quat_t quaternionFromHeading(const double heading);
 
     //}
 
@@ -258,6 +290,14 @@ namespace mrs_lib
     double sphericalTriangleArea(Eigen::Vector3d a, Eigen::Vector3d b, Eigen::Vector3d c);
 
     //}
+
+    // | ------------------ Conversion functions ------------------ |
+
+    geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what);
+    geometry_msgs::Point fromEigen(const Eigen::Vector3d& what);
+    
+    Eigen::Vector3d toEigen(const geometry_msgs::Point& what);
+    Eigen::Quaterniond toEigen(const geometry_msgs::Quaternion& what);
 
   }  // namespace geometry
 }  // namespace mrs_lib

--- a/include/mrs_lib/geometry/misc.h
+++ b/include/mrs_lib/geometry/misc.h
@@ -51,7 +51,12 @@ namespace mrs_lib
      * \returns the heading angle.
      *
      */
-    double headingFromRot(const quat_t& rot);
+    template <typename T>
+    double headingFromRot(const T& rot)
+    {
+      const vec3_t rot_vec = rot*vec3_t::UnitX();
+      return std::atan2(rot_vec.y(), rot_vec.x());
+    }
 
     //}
 

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -1,8 +1,9 @@
 // clang: MatousFormat
 
-/**  \file
+/**  \file Implements the Transformer class - wrapper for ROS's TF2 lookups and transformations.
  *   \brief A wrapper for easier work with tf2 transformations.
  *   \author Tomas Baca - tomas.baca@fel.cvut.cz
+ *   \author Matouš Vrba - matous.vrba@fel.cvut.cz
  */
 #ifndef TRANSFORMER_H
 #define TRANSFORMER_H
@@ -58,8 +59,9 @@ namespace mrs_lib
   static const std::string LATLON_ORIGIN = "latlon_origin";
 
   /**
-   * @brief tf wrapper that simplifies transforming stuff, adding caching, frame_id deduction and simple functions for one-time execution without getting the
-   * transform first
+   * \brief A convenience wrapper class for ROS's native TF2 API to simplify transforming of various messages.
+   *
+   * Implements optional automatic frame prefix deduction, seamless transformation lattitude/longitude coordinates and UTM coordinates, simple transformation of MRS messages etc.
    */
   /* class Transformer //{ */
 
@@ -70,25 +72,36 @@ namespace mrs_lib
     /* Constructor and overloads //{ */
 
     /**
-     * @brief the basic constructor
+     * \brief A convenience constructor that doesn't initialize anything.
+     *
+     * This constructor is just to enable usign the Transformer as a member variable of nodelets etc.
+     * To actually initialize the class, use the alternative constructor.
+     *
+     * \note This constructor doesn't initialize the TF2 transform listener and all calls to the transformation-related methods of an object constructed using this method will fail.
      */
     Transformer();
 
     /**
-     * @brief the constructor
+     * @brief The main constructor that actually initializes stuff.
      *
-     * @param node_name the name of the node running the transformer, is used in ROS prints
+     * This constructor initializes the class and the TF2 transform listener.
+     *
+     * @param node_name the name of the node running the transformer, is used in ROS prints. If you don't care, just set it to an empty string.
      */
     Transformer(const std::string& node_name);
 
     //}
 
+    // | ------------------ Configuration methods ----------------- |
+
     /* setDefaultFrame() //{ */
 
     /**
-     * @brief Sets the default frame ID to be used instead of any empty frame ID.
+     * \brief Sets the default frame ID to be used instead of any empty frame ID.
      *
-     * @param The default frame ID.
+     * Set to an empty string to disable this functionality (disabled by default).
+     *
+     * \param frame_id the default frame ID.
      */
     void setDefaultFrame(const std::string& frame_id)
     {
@@ -100,9 +113,11 @@ namespace mrs_lib
     /* setDefaultPrefix() //{ */
 
     /**
-     * @brief Sets the default frame ID prefix to be used if no prefix is present in the frame.
+     * \brief Sets the default frame ID prefix to be used if no prefix is present in the frame.
      *
-     * @param The default frame ID prefix.
+     * Set to an empty string to disable this functionality (disabled by default).
+     *
+     * \param prefix the default frame ID prefix.
      */
     void setDefaultPrefix(const std::string& prefix)
     {
@@ -114,45 +129,113 @@ namespace mrs_lib
     /* setLatLon() //{ */
 
     /**
-     * @brief Sets the curret lattitude and longitude for UTM zone calculation.
+     * \brief Sets the curret lattitude and longitude for UTM zone calculation.
      *
-     * The transformer uses this to deduce the current UTM fly zone
-     * used for transforming stuff to latlon_origin.
+     * The Transformer uses this to deduce the current UTM zone used for transforming stuff to latlon_origin.
+     * \note Any transformation to latlon_origin will fail if this function is not called!
      *
-     * @param lat latitude in degrees
-     * @param lon longitude in degrees
+     * \param lat the latitude in degrees.
+     * \param lon the longitude in degrees.
      */
     void setLatLon(const double lat, const double lon);
+
+    //}
+
+    /* setLookupTimeout() //{ */
+
+    /**
+     * \brief Set a timeout for transform lookup.
+     *
+     * The transform lookup operation will block up to this duration if the transformation is not available immediately.
+     *
+     * \note This functionality is disabled by default.
+     *
+     * \param timeout the lookup timeout. Set to zero to disable blocking.
+     */
+    void setLookupTimeout(const ros::Duration timeout = ros::Duration(0))
+    {
+      lookup_timeout_ = timeout;
+    }
+
+    //}
+
+    /* retryLookupNewest() //{ */
+
+    /**
+     * \brief Enable/disable retry of a failed transform lookup with \p ros::Time(0).
+     *
+     * If enabled, a failed transform lookup will be retried.
+     * The new try will ignore the requested timestamp and will attempt to fetch the latest transformation between the two frames.
+     *
+     * \note This functionality is disabled by default.
+     *
+     * \param retry enables or disables retry.
+     */
+    void retryLookupNewest(const bool retry = true)
+    {
+      retry_lookup_newest_ = retry;
+    }
+
+    //}
+    
+    /* beQuiet() //{ */
+
+    /**
+     * \brief Enable/disable some prints that may be too noisy.
+     *
+     * \note This functionality is disabled by default.
+     *
+     * \param quiet enables or disables quiet mode.
+     */
+    void beQuiet(const bool quiet = true)
+    {
+      quiet_ = quiet;
+    }
 
     //}
 
     /* transformSingle() //{ */
 
     /**
-     * @brief Transforms a single message to a new frame.
+     * \brief Transforms a single variable to a new frame and returns it or \p std::nullopt if transformation fails.
      *
-     * @param to_frame The target fram ID.
-     * @param what The object to be transformed.
+     * \param what the object to be transformed.
+     * \param to_frame the target frame ID.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<T> transformSingle(const std::string& to_frame, const T& what);
+    [[nodiscard]] std::optional<T> transformSingle(const T& what, const std::string& to_frame);
 
     /**
-     * @brief Transforms a single message to a new frame.
+     * \brief Transforms a single variable to a new frame and returns it or \p std::nullopt if transformation fails.
+     *
+     * A convenience overload for headerless variables.
+     *
+     * \param from_frame the original target frame ID.
+     * \param what the object to be transformed.
+     * \param to_frame the target frame ID.
+     * \param time_stamp the time of the transformation.
+     *
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     */
+    template <class T>
+    [[nodiscard]] std::optional<T> transformSingle(const std::string& from_frame_raw, const T& what, const std::string& to_frame_raw, const ros::Time& time_stamp = ros::Time(0));
+
+    /**
+     * \brief Transforms a single variable to a new frame.
      *
      * A convenience override for shared pointers to const.
      *
-     * @param to_frame The target fram ID.
-     * @param what The object to be transformed.
+     * \param what The object to be transformed.
+     * \param to_frame The target fram ID.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<boost::shared_ptr<T>> transformSingle(const std::string& to_frame, const boost::shared_ptr<const T>& what)
+    [[nodiscard]] std::optional<boost::shared_ptr<T>> transformSingle(const boost::shared_ptr<const T>& what, const std::string& to_frame)
     {
-      auto ret = transformSingle(to_frame, *what);
+      auto ret = transformSingle(*what, to_frame);
       if (ret == std::nullopt)
         return std::nullopt;
       else
@@ -160,51 +243,50 @@ namespace mrs_lib
     }
 
     /**
-     * @brief Transforms a single message to a new frame.
+     * \brief Transforms a single variable to a new frame.
      *
      * A convenience override for shared pointers.
      *
-     * @param to_frame The target fram ID.
-     * @param what The object to be transformed.
+     * \param what The object to be transformed.
+     * \param to_frame The target fram ID.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<boost::shared_ptr<T>> transformSingle(const std::string& to_frame, const boost::shared_ptr<T>& what)
+    [[nodiscard]] std::optional<boost::shared_ptr<T>> transformSingle(const boost::shared_ptr<T>& what, const std::string& to_frame)
     {
-      return transformSingle(to_frame, boost::shared_ptr<const T>(what));
+      return transformSingle(boost::shared_ptr<const T>(what), to_frame);
     }
-
 
     //}
 
     /* transform() //{ */
 
     /**
-     * @brief Transform a message to new frame using a particular transformation.
+     * \brief Transform a variable to new frame using a particular transformation.
      *
-     * @param tf The transformation to be used.
-     * @param what The object to be transformed.
+     * \param tf The transformation to be used.
+     * \param what The object to be transformed.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<T> transform(const geometry_msgs::TransformStamped& tf, const T& what);
+    [[nodiscard]] std::optional<T> transform(const T& what, const geometry_msgs::TransformStamped& tf);
 
     /**
-     * @brief Transform a message to new frame using a particular transformation.
+     * \brief Transform a variable to new frame using a particular transformation.
      *
      * A convenience override for shared pointers to const.
      *
-     * @param tf The transformation to be used.
-     * @param what The object to be transformed.
+     * \param tf The transformation to be used.
+     * \param what The object to be transformed.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<boost::shared_ptr<T>> transform(const geometry_msgs::TransformStamped& tf, const boost::shared_ptr<const T>& what)
+    [[nodiscard]] std::optional<boost::shared_ptr<T>> transform(const boost::shared_ptr<const T>& what, const geometry_msgs::TransformStamped& tf)
     {
-      auto ret = transform(tf, *what);
+      auto ret = transform(*what, tf);
       if (ret == std::nullopt)
         return std::nullopt;
       else
@@ -212,19 +294,19 @@ namespace mrs_lib
     }
 
     /**
-     * @brief Transform a message to new frame using a particular transformation.
+     * \brief Transform a variable to new frame using a particular transformation.
      *
      * A convenience override for shared pointers.
      *
-     * @param tf The transformation to be used.
-     * @param what The object to be transformed.
+     * \param tf The transformation to be used.
+     * \param what The object to be transformed.
      *
-     * @return \p std::nullopt if failed, optional containing the transformed object otherwise.
+     * \return \p std::nullopt if failed, optional containing the transformed object otherwise.
      */
     template <class T>
-    [[nodiscard]] std::optional<boost::shared_ptr<T>> transform(const geometry_msgs::TransformStamped& tf, const boost::shared_ptr<T>& what)
+    [[nodiscard]] std::optional<boost::shared_ptr<T>> transform(const boost::shared_ptr<T>& what, const geometry_msgs::TransformStamped& tf)
     {
-      return transform(tf, boost::shared_ptr<const T>(what));
+      return transform(boost::shared_ptr<const T>(what), tf);
     }
 
     //}
@@ -232,43 +314,48 @@ namespace mrs_lib
     /* getTransform() //{ */
 
     /**
-     * @brief Gets a transform between two frames in a given time.
+     * \brief Obtains a transform between two frames in a given time.
      *
-     * @param from_frame The original frame of the transformation.
-     * @param to_frame The target frame of the transformation.
-     * @param time_stamp The time stamp of the transformation.
+     * \param from_frame The original frame of the transformation.
+     * \param to_frame The target frame of the transformation.
+     * \param time_stamp The time stamp of the transformation. (0 will get the latest)
      *
-     * @return \p std::nullopt if failed, optional containing the requested transformation otherwise.
+     * \return \p std::nullopt if failed, optional containing the requested transformation otherwise.
      */
     [[nodiscard]] std::optional<geometry_msgs::TransformStamped> getTransform(const std::string& from_frame, const std::string& to_frame, const ros::Time& time_stamp = ros::Time(0));
+
+    /**
+     * \brief Obtains a transform between two frames in a given time.
+     *
+     * This overload enables the user to select a different time of the source frame and the target frame.
+     *
+     * \param from_frame The original frame of the transformation.
+     * \param from_stamp The time at which the original frame should be evaluated. (0 will get the latest)
+     * \param to_frame The target frame of the transformation.
+     * \param to_stamp The time to which the data should be transformed. (0 will get the latest) 
+     * \param fixed_frame The frame that may be assumed constant in time (the "world" frame).
+     *
+     * \return \p std::nullopt if failed, optional containing the requested transformation otherwise.
+     *
+     * \note An example of when this API may be useful is explained here: http://wiki.ros.org/tf2/Tutorials/Time%20travel%20with%20tf2%20%28C%2B%2B%29
+     */
+    [[nodiscard]] std::optional<geometry_msgs::TransformStamped> getTransform(const std::string& from_frame, const ros::Time& from_stamp, const std::string& to_frame, const ros::Time& to_stamp, const std::string& fixed_frame);
 
     //}
 
     /* resolveFrame() //{ */
     /**
-     * @brief Deduce the full frame ID from a shortened or empty string.
+     * \brief Deduce the full frame ID from a shortened or empty string using current default prefix and default frame rules.
      *
-     * example:
-     *   "" -> "uav1/gps_origin" (if the UAV is currently controlled in the gps_origin)
+     * example assuming default prefix is "uav1" and default frame is "uav1/gps_origin":
+     *   "" -> "uav1/gps_origin"
      *   "local_origin" -> "uav1/local_origin"
      *
-     * @param frame_id The frame ID to be resolved.
+     * \param frame_id The frame ID to be resolved.
      *
-     * @return The resolved frame ID.
+     * \return The resolved frame ID.
      */
     std::string resolveFrame(const std::string& frame_id);
-    //}
-
-    /* configuration methods //{ */
-    void retryLookupNewest(const bool retry = true)
-    {
-      retry_lookup_newest_ = retry;
-    }
-    
-    void beQuiet(const bool quiet = true)
-    {
-      quiet_ = quiet;
-    }
     //}
 
   private:
@@ -278,16 +365,16 @@ namespace mrs_lib
      * @brief keeps track whether a non-basic constructor was called and the transform listener is initialized
      */
     bool initialized_ = false;
+    std::string node_name_;
 
-    std::mutex mutex_tf_buffer_;
     tf2_ros::Buffer tf_buffer_;
     std::unique_ptr<tf2_ros::TransformListener> tf_listener_ptr_;
 
-    std::string default_frame_id_;
-    std::string prefix_;
-    std::string node_name_;
-
+    // user-configurable options
+    std::string default_frame_id_ = "";
+    std::string prefix_ = "";
     bool quiet_ = false;
+    ros::Duration lookup_timeout_ = ros::Duration(0);
     bool retry_lookup_newest_ = false;
 
     bool got_utm_zone_ = false;
@@ -301,13 +388,13 @@ namespace mrs_lib
     std::optional<Eigen::Vector3d> transformImpl(const geometry_msgs::TransformStamped& tf, const Eigen::Vector3d& what);
 
     template <class T>
-    std::optional<T> doTransform(const geometry_msgs::TransformStamped& tf, const T& what);
+    std::optional<T> doTransform(const T& what, const geometry_msgs::TransformStamped& tf);
 
     //}
 
     // | ------------------- some helper methods ------------------ |
   public:
-    /*  //{ */
+    /* frame_from(), frame_to() and inverse() methods //{ */
     
     static constexpr const std::string& frame_from(const geometry_msgs::TransformStamped& msg)
     {
@@ -339,7 +426,7 @@ namespace mrs_lib
     //}
 
   private:
-    /*  //{ */
+    /* create_transform() method //{ */
     static geometry_msgs::TransformStamped create_transform(const std::string& from_frame, const std::string& to_frame, const ros::Time& time_stamp)
     {
       geometry_msgs::TransformStamped ret;
@@ -360,16 +447,57 @@ namespace mrs_lib
     }
     //}
 
-  public:
+    /* copyChangeFrame() and related methods //{ */
+
+    // helper type and member for detecting whether a message has a header using SFINAE
+    template<typename T>
+    using has_header_member_chk = decltype( std::declval<T&>().header );
+    template<typename T>
+    static constexpr bool has_header_member_v = std::experimental::is_detected<has_header_member_chk, T>::value;
+    
+    template <typename msg_t>
+    std_msgs::Header getHeader(const msg_t& msg);
+    template <typename pt_t>
+    std_msgs::Header getHeader(const pcl::PointCloud<pt_t>& cloud);
+    
+    template <typename msg_t>
+    void setHeader(msg_t& msg, const std_msgs::Header& header);
+    template <typename pt_t>
+    void setHeader(pcl::PointCloud<pt_t>& cloud, const std_msgs::Header& header);
+    
+    template <typename T>
+    T copyChangeFrame(const T& what, const std::string& frame_id);
+    
+    //}
+
+    /* methods for converting between lattitude/longitude and UTM coordinates //{ */
     Eigen::Vector3d LLtoUTM(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
     geometry_msgs::Point LLtoUTM(const geometry_msgs::Point& what, const std::string& prefix);
     geometry_msgs::Pose LLtoUTM(const geometry_msgs::Pose& what, const std::string& prefix);
     geometry_msgs::PoseStamped LLtoUTM(const geometry_msgs::PoseStamped& what, const std::string& prefix);
-
+    
     std::optional<Eigen::Vector3d> UTMtoLL(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
     std::optional<geometry_msgs::Point> UTMtoLL(const geometry_msgs::Point& what, const std::string& prefix);
     std::optional<geometry_msgs::Pose> UTMtoLL(const geometry_msgs::Pose& what, const std::string& prefix);
     std::optional<geometry_msgs::PoseStamped> UTMtoLL(const geometry_msgs::PoseStamped& what, const std::string& prefix);
+    
+    // helper types and member for detecting whether the UTMtoLL and LLtoUTM methods are defined for a certain message
+    template<typename T>
+    using UTMLL_method_chk = decltype(Transformer().UTMtoLL(std::declval<const T&>(), ""));
+    template<typename T>
+    using LLUTM_method_chk = decltype(Transformer().LLtoUTM(std::declval<const T&>(), ""));
+    template<typename T>
+    static constexpr bool UTMLL_exists_v = std::experimental::is_detected<UTMLL_method_chk, T>::value && std::experimental::is_detected<LLUTM_method_chk, T>::value;
+    //}
+
+    /* methods for converting between Eigen and geometry_msgs types //{ */
+    geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what);
+    geometry_msgs::Point fromEigen(const Eigen::Vector3d& what);
+    
+    Eigen::Vector3d toEigen(const geometry_msgs::Point& what);
+    Eigen::Quaterniond toEigen(const geometry_msgs::Quaternion& what);
+    //}
+
   };
 
 #include <impl/transformer.hpp>

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -99,9 +99,11 @@ namespace mrs_lib
     /**
      * \brief Sets the default frame ID to be used instead of any empty frame ID.
      *
-     * Set to an empty string to disable this functionality (disabled by default).
+     * If you call e.g. the transform() method with a message that has an empty header.frame_id field, this value will be used instead.
      *
-     * \param frame_id the default frame ID.
+     * \param frame_id the default frame ID. Use an empty string to disable default frame ID deduction.
+     *
+     * \note Disabled by default.
      */
     void setDefaultFrame(const std::string& frame_id)
     {
@@ -115,9 +117,15 @@ namespace mrs_lib
     /**
      * \brief Sets the default frame ID prefix to be used if no prefix is present in the frame.
      *
-     * Set to an empty string to disable this functionality (disabled by default).
+     * If you call any method with a frame ID that doesn't begin with this string, it will be automatically prefixed including a forward slash between the prefix and raw frame ID.
+     * The forward slash should therefore *not* be included in the prefix.
      *
-     * \param prefix the default frame ID prefix.
+     * Example frame ID resolution assuming default prefix is "uav1":
+     *   "local_origin" -> "uav1/local_origin"
+     *
+     * \param prefix the default frame ID prefix (without the forward slash at the end). Use an empty string to disable default frame ID prefixing.
+     *
+     * \note Disabled by default. The prefix will be applied as a namespace (with a forward slash between the prefix and raw frame ID).
      */
     void setDefaultPrefix(const std::string& prefix)
     {
@@ -132,10 +140,11 @@ namespace mrs_lib
      * \brief Sets the curret lattitude and longitude for UTM zone calculation.
      *
      * The Transformer uses this to deduce the current UTM zone used for transforming stuff to latlon_origin.
-     * \note Any transformation to latlon_origin will fail if this function is not called!
      *
      * \param lat the latitude in degrees.
      * \param lon the longitude in degrees.
+     *
+     * \note Any transformation to latlon_origin will fail if this function is not called first!
      */
     void setLatLon(const double lat, const double lon);
 
@@ -148,7 +157,7 @@ namespace mrs_lib
      *
      * The transform lookup operation will block up to this duration if the transformation is not available immediately.
      *
-     * \note This functionality is disabled by default.
+     * \note Disabled by default.
      *
      * \param timeout the lookup timeout. Set to zero to disable blocking.
      */
@@ -167,7 +176,7 @@ namespace mrs_lib
      * If enabled, a failed transform lookup will be retried.
      * The new try will ignore the requested timestamp and will attempt to fetch the latest transformation between the two frames.
      *
-     * \note This functionality is disabled by default.
+     * \note Disabled by default.
      *
      * \param retry enables or disables retry.
      */
@@ -183,9 +192,9 @@ namespace mrs_lib
     /**
      * \brief Enable/disable some prints that may be too noisy.
      *
-     * \note This functionality is disabled by default.
-     *
      * \param quiet enables or disables quiet mode.
+     *
+     * \note Disabled by default.
      */
     void beQuiet(const bool quiet = true)
     {
@@ -347,7 +356,7 @@ namespace mrs_lib
     /**
      * \brief Deduce the full frame ID from a shortened or empty string using current default prefix and default frame rules.
      *
-     * example assuming default prefix is "uav1" and default frame is "uav1/gps_origin":
+     * Example assuming default prefix is "uav1" and default frame is "uav1/gps_origin":
      *   "" -> "uav1/gps_origin"
      *   "local_origin" -> "uav1/local_origin"
      *
@@ -362,7 +371,7 @@ namespace mrs_lib
     /* private members, methods etc //{ */
 
     /**
-     * @brief keeps track whether a non-basic constructor was called and the transform listener is initialized
+     * \brief keeps track whether a non-basic constructor was called and the transform listener is initialized
      */
     bool initialized_ = false;
     std::string node_name_;

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -139,7 +139,7 @@ namespace mrs_lib
      */
     void setDefaultPrefix(const std::string& prefix)
     {
-      prefix_ = prefix;
+      prefix_ = prefix + "/";
     }
 
     //}
@@ -391,7 +391,7 @@ namespace mrs_lib
 
     // user-configurable options
     std::string default_frame_id_ = "";
-    std::string prefix_ = "";
+    std::string prefix_ = ""; // if not empty, includes the forward slash
     bool quiet_ = false;
     ros::Duration lookup_timeout_ = ros::Duration(0);
     bool retry_lookup_newest_ = false;
@@ -399,6 +399,7 @@ namespace mrs_lib
     bool got_utm_zone_ = false;
     char utm_zone_[10] = {};
 
+    // returns the first namespace prefix of the frame (if any) includin the forward slash
     std::string getFramePrefix(const std::string& frame_id);
 
     template <class T>

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -88,7 +88,7 @@ namespace mrs_lib
      *
      * @param node_name the name of the node running the transformer, is used in ROS prints. If you don't care, just set it to an empty string.
      */
-    Transformer(const std::string& node_name);
+    Transformer(const ros::NodeHandle& nh, const std::string& node_name = std::string());
 
     //}
 

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -139,7 +139,10 @@ namespace mrs_lib
      */
     void setDefaultPrefix(const std::string& prefix)
     {
-      prefix_ = prefix + "/";
+      if (prefix.empty())
+        prefix_ = "";
+      else
+        prefix_ = prefix + "/";
     }
 
     //}

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -305,8 +305,8 @@ namespace mrs_lib
 
     //}
 
-    public:
     // | ------------------- some helper methods ------------------ |
+  public:
     /*  //{ */
     
     static constexpr const std::string& frame_from(const geometry_msgs::TransformStamped& msg)
@@ -336,8 +336,10 @@ namespace mrs_lib
       tf2 = tf2.inverse();
       return create_transform(msg.child_frame_id, msg.header.frame_id, msg.header.stamp, tf2::toMsg(tf2));
     }
+    //}
 
-    private:
+  private:
+    /*  //{ */
     static geometry_msgs::TransformStamped create_transform(const std::string& from_frame, const std::string& to_frame, const ros::Time& time_stamp)
     {
       geometry_msgs::TransformStamped ret;
@@ -358,6 +360,7 @@ namespace mrs_lib
     }
     //}
 
+  public:
     Eigen::Vector3d LLtoUTM(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
     geometry_msgs::Point LLtoUTM(const geometry_msgs::Point& what, const std::string& prefix);
     geometry_msgs::Pose LLtoUTM(const geometry_msgs::Pose& what, const std::string& prefix);

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -88,6 +88,16 @@ namespace mrs_lib
      *
      * @param node_name the name of the node running the transformer, is used in ROS prints. If you don't care, just set it to an empty string.
      */
+    Transformer(const std::string& node_name = std::string());
+
+    /**
+     * @brief The main constructor that actually initializes stuff.
+     *
+     * This constructor initializes the class and the TF2 transform listener.
+     *
+     * @param nh        the node handle to be used for subscribing to the transformations.
+     * @param node_name the name of the node running the transformer, is used in ROS prints. If you don't care, just set it to an empty string.
+     */
     Transformer(const ros::NodeHandle& nh, const std::string& node_name = std::string());
 
     //}
@@ -407,22 +417,22 @@ namespace mrs_lib
     
     static constexpr const std::string& frame_from(const geometry_msgs::TransformStamped& msg)
     {
-      return msg.header.frame_id;
+      return msg.child_frame_id;
     }
     
     static constexpr std::string& frame_from(geometry_msgs::TransformStamped& msg)
     {
-      return msg.header.frame_id;
+      return msg.child_frame_id;
     }
 
     static constexpr const std::string& frame_to(const geometry_msgs::TransformStamped& msg)
     {
-      return msg.child_frame_id;
+      return msg.header.frame_id;
     }
 
     static constexpr std::string& frame_to(geometry_msgs::TransformStamped& msg)
     {
-      return msg.child_frame_id;
+      return msg.header.frame_id;
     }
 
     static geometry_msgs::TransformStamped inverse(const geometry_msgs::TransformStamped& msg)
@@ -430,7 +440,7 @@ namespace mrs_lib
       tf2::Transform tf2;
       tf2::fromMsg(msg.transform, tf2);
       tf2 = tf2.inverse();
-      return create_transform(msg.child_frame_id, msg.header.frame_id, msg.header.stamp, tf2::toMsg(tf2));
+      return create_transform(frame_to(msg), frame_from(msg), msg.header.stamp, tf2::toMsg(tf2));
     }
     //}
 
@@ -480,12 +490,10 @@ namespace mrs_lib
     //}
 
     /* methods for converting between lattitude/longitude and UTM coordinates //{ */
-    Eigen::Vector3d LLtoUTM(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
     geometry_msgs::Point LLtoUTM(const geometry_msgs::Point& what, const std::string& prefix);
     geometry_msgs::Pose LLtoUTM(const geometry_msgs::Pose& what, const std::string& prefix);
     geometry_msgs::PoseStamped LLtoUTM(const geometry_msgs::PoseStamped& what, const std::string& prefix);
     
-    std::optional<Eigen::Vector3d> UTMtoLL(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
     std::optional<geometry_msgs::Point> UTMtoLL(const geometry_msgs::Point& what, const std::string& prefix);
     std::optional<geometry_msgs::Pose> UTMtoLL(const geometry_msgs::Pose& what, const std::string& prefix);
     std::optional<geometry_msgs::PoseStamped> UTMtoLL(const geometry_msgs::PoseStamped& what, const std::string& prefix);

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -500,12 +500,12 @@ namespace mrs_lib
     std::optional<geometry_msgs::PoseStamped> UTMtoLL(const geometry_msgs::PoseStamped& what, const std::string& prefix);
     
     // helper types and member for detecting whether the UTMtoLL and LLtoUTM methods are defined for a certain message
-    template<typename T>
-    using UTMLL_method_chk = decltype(std::declval<Transformer>().UTMtoLL(std::declval<const T&>(), ""));
-    template<typename T>
-    using LLUTM_method_chk = decltype(std::declval<Transformer>().LLtoUTM(std::declval<const T&>(), ""));
-    template<typename T>
-    static constexpr bool UTMLL_exists_v = std::experimental::is_detected<UTMLL_method_chk, T>::value && std::experimental::is_detected<LLUTM_method_chk, T>::value;
+    template<class Class, typename Message>
+    using UTMLL_method_chk = decltype(std::declval<Class>().UTMtoLL(std::declval<const Message&>(), ""));
+    template<class Class, typename Message>
+    using LLUTM_method_chk = decltype(std::declval<Class>().LLtoUTM(std::declval<const Message&>(), ""));
+    template<class Class, typename Message>
+    static constexpr bool UTMLL_exists_v = std::experimental::is_detected<UTMLL_method_chk, Class, Message>::value && std::experimental::is_detected<LLUTM_method_chk, Class, Message>::value;
     //}
 
     /* methods for converting between Eigen and geometry_msgs types //{ */

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -237,8 +237,6 @@ namespace mrs_lib
      * @param from_frame The original frame of the transformation.
      * @param to_frame The target frame of the transformation.
      * @param time_stamp The time stamp of the transformation.
-     * @param use_last_if_fail If true, the latest available transformation will be used instead of time_stamp if the lookup fails.
-     * @param quiet Should not print excessively.
      *
      * @return \p std::nullopt if failed, optional containing the requested transformation otherwise.
      */
@@ -289,38 +287,21 @@ namespace mrs_lib
     std::string prefix_;
     std::string node_name_;
 
-    bool quiet_;
-    bool retry_lookup_newest_;
+    bool quiet_ = false;
+    bool retry_lookup_newest_ = false;
 
-    std::mutex mutex_current_control_frame_;
-    std::string current_control_frame_;
-    bool got_current_control_frame_ = false;
-
-    std::mutex mutex_utm_zone_;
     bool got_utm_zone_ = false;
-    char utm_zone_[10];
+    char utm_zone_[10] = {};
 
     std::string getFramePrefix(const std::string& frame_id);
 
     template <class T>
     std::optional<T> transformImpl(const geometry_msgs::TransformStamped& tf, const T& what);
     std::optional<mrs_msgs::ReferenceStamped> transformImpl(const geometry_msgs::TransformStamped& tf, const mrs_msgs::ReferenceStamped& what);
-    std::optional<geometry_msgs::PoseStamped> transformImpl(const geometry_msgs::TransformStamped& tf, const geometry_msgs::PoseStamped& what);
-    std::optional<geometry_msgs::Point> transformImpl(const geometry_msgs::TransformStamped& tf, const geometry_msgs::Point& what);
     std::optional<Eigen::Vector3d> transformImpl(const geometry_msgs::TransformStamped& tf, const Eigen::Vector3d& what);
 
     template <class T>
     std::optional<T> doTransform(const geometry_msgs::TransformStamped& tf, const T& what);
-
-    template <class T>
-    std::optional<T> transformFromLatLon(const std::string& to_frame, const ros::Time& at_time, const std::string& uav_prefix, const T& what);
-    std::optional<Eigen::Vector3d> transformFromLatLon(const std::string& to_frame, const ros::Time& at_time, const std::string& uav_prefix, const Eigen::Vector3d& what);
-    std::optional<geometry_msgs::Pose> transformFromLatLon(const std::string& to_frame, const ros::Time& at_time, const std::string& uav_prefix, const geometry_msgs::Pose& what);
-
-    template <class T>
-    std::optional<T> transformToLatLon(const std::string& from_frame, const ros::Time& at_time, const std::string& uav_prefix, const T& what);
-    std::optional<Eigen::Vector3d> transformToLatLon(const std::string& from_frame, const ros::Time& at_time, const std::string& uav_prefix, const Eigen::Vector3d& what);
-    std::optional<geometry_msgs::Pose> transformToLatLon(const std::string& from_frame, const ros::Time& at_time, const std::string& uav_prefix, const geometry_msgs::Pose& what);
 
     //}
 
@@ -377,6 +358,15 @@ namespace mrs_lib
     }
     //}
 
+    Eigen::Vector3d LLtoUTM(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
+    geometry_msgs::Point LLtoUTM(const geometry_msgs::Point& what, const std::string& prefix);
+    geometry_msgs::Pose LLtoUTM(const geometry_msgs::Pose& what, const std::string& prefix);
+    geometry_msgs::PoseStamped LLtoUTM(const geometry_msgs::PoseStamped& what, const std::string& prefix);
+
+    std::optional<Eigen::Vector3d> UTMtoLL(const Eigen::Vector3d& what, [[maybe_unused]] const std::string& prefix);
+    std::optional<geometry_msgs::Point> UTMtoLL(const geometry_msgs::Point& what, const std::string& prefix);
+    std::optional<geometry_msgs::Pose> UTMtoLL(const geometry_msgs::Pose& what, const std::string& prefix);
+    std::optional<geometry_msgs::PoseStamped> UTMtoLL(const geometry_msgs::PoseStamped& what, const std::string& prefix);
   };
 
 #include <impl/transformer.hpp>

--- a/include/mrs_lib/transformer.h
+++ b/include/mrs_lib/transformer.h
@@ -88,7 +88,7 @@ namespace mrs_lib
      *
      * @param node_name the name of the node running the transformer, is used in ROS prints. If you don't care, just set it to an empty string.
      */
-    Transformer(const std::string& node_name = std::string());
+    Transformer(const std::string& node_name);
 
     /**
      * @brief The main constructor that actually initializes stuff.
@@ -501,9 +501,9 @@ namespace mrs_lib
     
     // helper types and member for detecting whether the UTMtoLL and LLtoUTM methods are defined for a certain message
     template<typename T>
-    using UTMLL_method_chk = decltype(Transformer().UTMtoLL(std::declval<const T&>(), ""));
+    using UTMLL_method_chk = decltype(std::declval<Transformer>().UTMtoLL(std::declval<const T&>(), ""));
     template<typename T>
-    using LLUTM_method_chk = decltype(Transformer().LLtoUTM(std::declval<const T&>(), ""));
+    using LLUTM_method_chk = decltype(std::declval<Transformer>().LLtoUTM(std::declval<const T&>(), ""));
     template<typename T>
     static constexpr bool UTMLL_exists_v = std::experimental::is_detected<UTMLL_method_chk, T>::value && std::experimental::is_detected<LLUTM_method_chk, T>::value;
     //}

--- a/src/geometry/misc.cpp
+++ b/src/geometry/misc.cpp
@@ -181,40 +181,5 @@ namespace mrs_lib
 
     //}
 
-    geometry_msgs::Point fromEigen(const Eigen::Vector3d& what)
-    {
-      geometry_msgs::Point pt;
-      pt.x = what.x();
-      pt.y = what.y();
-      pt.z = what.z();
-      return pt;
-    }
-
-    Eigen::Vector3d toEigen(const geometry_msgs::Point& what)
-    {
-      return {what.x, what.y, what.z};
-    }
-
-    geometry_msgs::Quaternion fromEigen(const Eigen::Quaterniond& what)
-    {
-      geometry_msgs::Quaternion q;
-      q.x = what.x();
-      q.y = what.y();
-      q.z = what.z();
-      q.w = what.w();
-      return q;
-    }
-
-    Eigen::Quaterniond toEigen(const geometry_msgs::Quaternion& what)
-    {
-      // better to do this manually than through the constructor to avoid ambiguities (e.g. position of x and w)
-      Eigen::Quaterniond q;
-      q.x() = what.x;
-      q.y() = what.y;
-      q.z() = what.z;
-      q.w() = what.w;
-      return q;
-    }
-
   }  // namespace geometry
 }  // namespace mrs_lib

--- a/src/geometry/misc.cpp
+++ b/src/geometry/misc.cpp
@@ -23,14 +23,6 @@ namespace mrs_lib
 
     //}
 
-    /* headingFromRot() //{ */
-    double headingFromRot(const quat_t& rot)
-    {
-      const vec3_t rot_vec = rot*vec3_t::UnitX();
-      return std::atan2(rot_vec.y(), rot_vec.x());
-    }
-    //}
-
     /* angleBetween() //{ */
 
     double angleBetween(const vec3_t& vec1, const vec3_t& vec2)

--- a/src/transformer/example.cpp
+++ b/src/transformer/example.cpp
@@ -7,8 +7,10 @@ int main(int argc, char* argv[])
   ros::NodeHandle nh("~");
   mrs_lib::Transformer tfr(nh);
 
-  const std::string from = "from";
-  const std::string to = "to";
+  const std::string from = mrs_lib::LATLON_ORIGIN;
+  const std::string to = mrs_lib::UTM_ORIGIN;
+  geometry_msgs::Point pt;
+
   ros::Rate r(10); // 10 hz
   while (ros::ok())
   {
@@ -21,7 +23,11 @@ int main(int argc, char* argv[])
       std::cout << "Was looking for transformation from \"" << from << "\" to \"" << to << "\".\n";
       std::cout << "Received transformation from \"" << mrs_lib::Transformer::frame_from(tf) << "\" to \"" << mrs_lib::Transformer::frame_to(tf) << "\":\n";
       std::cout << tf << std::endl;
+      const auto tfd_opt = tfr.transform(pt, tf);
+      std::cout << tfd_opt.value() << std::endl;
       break;
     }
   }
+
+  return 0;
 }

--- a/src/transformer/example.cpp
+++ b/src/transformer/example.cpp
@@ -1,5 +1,6 @@
 #include <mrs_lib/transformer.h>
 
+// very rudimentary
 int main(int argc, char* argv[])
 {
   ros::init(argc, argv, "transformer_example");
@@ -16,8 +17,10 @@ int main(int argc, char* argv[])
     const auto tf_opt = tfr.getTransform(from, to);
     if (tf_opt.has_value())
     {
-      std::cout << "Transformation from " << from << " to " << to << ":\n";
-      std::cout << tf_opt.value() << std::endl;
+      const auto tf = tf_opt.value();
+      std::cout << "Was looking for transformation from \"" << from << "\" to \"" << to << "\".\n";
+      std::cout << "Received transformation from \"" << mrs_lib::Transformer::frame_from(tf) << "\" to \"" << mrs_lib::Transformer::frame_to(tf) << "\":\n";
+      std::cout << tf << std::endl;
       break;
     }
   }

--- a/src/transformer/example.cpp
+++ b/src/transformer/example.cpp
@@ -1,6 +1,6 @@
 #include <mrs_lib/transformer.h>
 
-// very rudimentary
+// very rudimentary usage example, more of a test
 int main(int argc, char* argv[])
 {
   ros::init(argc, argv, "transformer_example");

--- a/src/transformer/example.cpp
+++ b/src/transformer/example.cpp
@@ -1,0 +1,24 @@
+#include <mrs_lib/transformer.h>
+
+int main(int argc, char* argv[])
+{
+  ros::init(argc, argv, "transformer_example");
+  ros::NodeHandle nh("~");
+  mrs_lib::Transformer tfr(nh);
+
+  const std::string from = "from";
+  const std::string to = "to";
+  ros::Rate r(10); // 10 hz
+  while (ros::ok())
+  {
+    ros::spinOnce();
+    r.sleep();
+    const auto tf_opt = tfr.getTransform(from, to);
+    if (tf_opt.has_value())
+    {
+      std::cout << "Transformation from " << from << " to " << to << ":\n";
+      std::cout << tf_opt.value() << std::endl;
+      break;
+    }
+  }
+}

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -23,227 +23,14 @@ namespace mrs_lib
   {
   }
 
-  Transformer::Transformer(const std::string& node_name, const std::string& uav_name)
+  Transformer::Transformer(const std::string& node_name)
+    : tf_listener_ptr_(std::make_unique<tf2_ros::TransformListener>(tf_buffer_, node_name)), initialized_(true)
   {
-
-    this->node_name_ = node_name;
-    this->uav_name_ = uav_name;
-
-    if (uav_name == "")
-    {
-      this->got_uav_name_ = false;
-    } else
-    {
-      this->got_uav_name_ = true;
-    }
-
-    this->current_control_frame_ = "";
-
-    this->tf_listener_ptr_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_, node_name);
-
-    this->is_initialized_ = true;
-  }
-
-  Transformer::Transformer(const std::string& node_name) : Transformer(node_name, "")
-  {
-  }
-
-  Transformer::Transformer(const Transformer& other)
-  {
-
-    this->is_initialized_ = other.is_initialized_;
-    this->node_name_ = other.node_name_;
-    this->uav_name_ = other.uav_name_;
-    this->got_uav_name_ = other.got_uav_name_;
-
-    {
-      std::scoped_lock lock(other.mutex_current_control_frame_);
-
-      this->current_control_frame_ = other.current_control_frame_;
-      this->got_current_control_frame_ = other.got_current_control_frame_;
-    }
-
-    if (this->is_initialized_)
-    {
-      this->tf_listener_ptr_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_, this->node_name_);
-    }
-  }
-
-  Transformer& Transformer::operator=(const Transformer& other)
-  {
-
-    if (this == &other)
-    {
-      return *this;
-    }
-
-    this->is_initialized_ = other.is_initialized_;
-    this->node_name_ = other.node_name_;
-    this->uav_name_ = other.uav_name_;
-    this->got_uav_name_ = other.got_uav_name_;
-
-    {
-      std::scoped_lock lock(other.mutex_current_control_frame_);
-
-      this->current_control_frame_ = other.current_control_frame_;
-      this->got_current_control_frame_ = other.got_current_control_frame_;
-    }
-
-    if (this->is_initialized_)
-    {
-      this->tf_listener_ptr_ = std::make_unique<tf2_ros::TransformListener>(tf_buffer_, this->node_name_);
-    }
-
-    return *this;
   }
 
   //}
 
-  /* /1* transform() //{ *1/ */
-
-  /* std::optional<Eigen::MatrixXd> Transformer::transform(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what) */
-  /* { */
-  /*   return transformImpl(tf, what); */
-  /* } */
-
-
-  /* //} */
-
   /* transformImpl() //{ */
-
-  /* /1* Eigen::MatrixXd //{ *1/ */
-
-  /* std::optional<Eigen::MatrixXd> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what) */
-  /* { */
-  /*   if (what.rows() == 2) */
-  /*   { */
-  /*     const std::optional<Eigen::MatrixXd> tmp = transformMat2(tf, what); */
-  /*     if (tmp.has_value()) */
-  /*       return tmp.value(); */
-  /*     else */
-  /*       return std::nullopt; */
-  /*   } */
-  /*   else if (what.rows() == 3) */
-  /*   { */
-  /*     const std::optional<Eigen::MatrixXd> tmp = transformMat3(tf, what); */
-  /*     if (tmp.has_value()) */
-  /*       return tmp.value(); */
-  /*     else */
-  /*       return std::nullopt; */
-  /*   } */
-  /*   else */
-  /*   { */
-  /*     ROS_ERROR_THROTTLE(1.0, "[%s]: transformation of a %ldx%ld matrix is not implemented!", node_name_.c_str(), what.rows(), what.cols()); */
-  /*     return std::nullopt; */
-  /*   } */
-  /* } */
-
-  /* //} */
-
-  /* /1* Eigen::Matrix<double, 2, -1> //{ *1/ */
-
-  /* std::optional<Eigen::MatrixXd> Transformer::transformMat2(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what) */
-  /* { */
-  /*   assert(what.rows() == 2); */
-  /*   Eigen::MatrixXd mat = Eigen::MatrixXd::Zero(3, what.cols()); */
-  /*   mat.block(0, 0, 2, what.cols()) = what; */
-  /*   const std::optional<Eigen::MatrixXd> tmp = transformMat3(tf, mat); */
-  /*   if (tmp.has_value()) */
-  /*     return tmp.value().block(0, 0, 2, what.cols()); */
-  /*   else */
-  /*     return std::nullopt; */
-  /* } */
-
-  /* //} */
-
-  /* /1* Eigen::Matrix<double, 3, -1> //{ *1/ */
-
-  /* std::optional<Eigen::MatrixXd> Transformer::transformMat3(const mrs_lib::TransformStamped& tf, const Eigen::MatrixXd& what) */
-  /* { */
-  /*   assert(what.rows() == 3); */
-  /*   Eigen::MatrixXd ret(what.rows(), what.cols()); */
-  /*   std::string latlon_frame_name = resolveFrameName(LATLON_ORIGIN); */
-  /*   Eigen::Matrix<double, 3, Eigen::Dynamic, Eigen::DontAlign> mat(what); */
-  /*   /1* mat = what; *1/ */
-
-  /*   // check for transformation from LAT-LON GPS */
-  /*   /1* transformation from LAT-LON GPS //{ *1/ */
-
-  /*   if (tf.from() == latlon_frame_name) */
-  /*   { */
-  /*     // utm_x and utm_y are now in 'utm_origin' frame */
-  /*     const std::string uav_prefix = getUAVFramePrefix(tf.from()); */
-  /*     const std::string utm_frame_name = uav_prefix + "/utm_origin"; */
-
-  /*     // transform from 'utm_origin' to the desired frame */
-  /*     const auto utm_origin_to_end_tf_opt = getTransform(utm_frame_name, tf.to(), tf.stamp()); */
-  /*     if (!utm_origin_to_end_tf_opt.has_value()) */
-  /*       return std::nullopt; */
-  /*     const Eigen::Affine3d tf_eig = utm_origin_to_end_tf_opt.value().getTransformEigen(); */
-
-  /*     for (int it = 0; it < ret.cols(); it++) */
-  /*     { */
-  /*       Eigen::Vector3d vec = mat.col(it); */
-  /*       // convert LAT-LON to UTM */
-  /*       mrs_lib::UTM(vec.x(), vec.y(), &vec.x(), &vec.y()); */
-  /*       // transform to the desired target frame */
-  /*       ret.col(it) = tf_eig*vec; */
-  /*     } */
-  /*   } */
-
-  /*   //} */
-  /*   // check for transformation to LAT-LON GPS */
-  /*   /1* transformation to LAT-LON GPS //{ *1/ */
-
-  /*   else if (tf.to() == latlon_frame_name) */
-  /*   { */
-  /*     std::string utm_zone; */
-  /*     { */
-  /*       std::scoped_lock lock(mutex_utm_zone_); */
-  /*       // if no UTM zone was specified by the user, we don't know which one to use... */
-  /*       if (!got_utm_zone_) */
-  /*       { */
-  /*         ROS_WARN_THROTTLE(1.0, "[%s]: cannot transform to latlong, missing UTM zone (did you call setCurrentLatLon()?)", node_name_.c_str()); */
-  /*         return std::nullopt; */
-  /*       } */
-  /*       utm_zone = utm_zone_; */
-  /*     } */
-
-  /*     // first, transform from the desired frame to 'utm_origin' */
-  /*     const std::string uav_prefix = getUAVFramePrefix(tf.to()); */
-  /*     std::string utm_frame_name = uav_prefix + "/utm_origin"; */
-
-  /*     const auto start_to_utm_origin_tf_opt = getTransform(tf.from(), utm_frame_name, tf.stamp()); */
-  /*     if (!start_to_utm_origin_tf_opt.has_value()) */
-  /*       return std::nullopt; */
-  /*     const Eigen::Affine3d tf_eig = start_to_utm_origin_tf_opt.value().getTransformEigen(); */
-
-  /*     // transform to the intermediate (UTM) target frame */
-  /*     mat = tf_eig*mat; */
-  /*     for (int it = 0; it < ret.cols(); it++) */
-  /*     { */
-  /*       Eigen::Vector3d vec = mat.col(it); */
-  /*       // now apply the nonlinear transformation from UTM to LAT-LON */
-  /*       mrs_lib::UTMtoLL(vec.y(), vec.x(), utm_zone, vec.x(), vec.y()); */
-  /*       ret.col(it) = vec; */
-  /*     } */
-  /*   } */
-
-  /*   //} */
-  /*   // in case of a normal transformation just transform each vector separately */
-  /*   /1* regular transformation //{ *1/ */
-
-  /*   else */
-  /*   { */
-  /*     const Eigen::Affine3d tf_eig = tf.getTransformEigen(); */
-  /*     ret = tf_eig*mat; */
-  /*   } */
-
-  /*   //} */
-  /*   return ret; */
-  /* } */
-
-  /* //} */
 
   std::optional<mrs_msgs::ReferenceStamped> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const mrs_msgs::ReferenceStamped& what)
   {
@@ -446,7 +233,7 @@ namespace mrs_lib
     catch (const mrs_lib::AttitudeConverter::GetHeadingException& e)
     {
       ROS_ERROR_THROTTLE(1.0, "[%s]: exception caught while transforming mrs_msgs::Reference's heading: %s", node_name_.c_str(), e.what());
-      throw mrs_lib::Transformer::TransformException();
+      return std::nullopt;
     }
 
     return ret;
@@ -534,235 +321,30 @@ namespace mrs_lib
 
   //}
 
-  /* resolveFrameName() //{ */
+  /* resolve_frame() //{ */
 
-  std::string Transformer::resolveFrameName(const std::string& in)
+  std::string Transformer::resolve_frame(const std::string& frame_id)
   {
+    if (frame_id.empty())
+      return default_frame_id_;
 
-    if (in == "")
-    {
+    // if there is a default prefix set and the frame does not start with it, prefix it
+    if (!prefix_.empty() && frame_id.substr(0, prefix_.length()) != prefix_)
+      return prefix_ + "/" + frame_id;
 
-      if (got_current_control_frame_)
-      {
-
-        std::scoped_lock lock(mutex_current_control_frame_);
-
-        return current_control_frame_;
-
-      } else
-      {
-
-        ROS_WARN_THROTTLE(
-            1.0, "[%s]: Transformer: could not resolve an empty frame_id, missing the current control frame (are you calling the setCurrentControlFrame()?)",
-            node_name_.c_str());
-
-        return "";
-      }
-    }
-
-    if (got_uav_name_)
-    {
-
-      if (in.substr(0, uav_name_.length()) != uav_name_)
-      {
-
-        return uav_name_ + "/" + in;
-
-      } else
-      {
-
-        return in;
-      }
-    }
-    /* else */
-    /* { */
-
-    /*   ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: could not deduce a namespaced frame_id '%s' (did you instance the Transformer with the uav_name argument?)",
-     */
-    /*                     node_name_.c_str(), in.c_str()); */
-    /* } */
-
-    return in;
+    return frame_id;
   }
 
   //}
 
-  /* checkUAVFramePrefix() //{ */
+  /* set_lat_lon() //{ */
 
-  std::string Transformer::getUAVFramePrefix(const std::string& in)
+  void set_lat_lon(const double lat, const double lon)
   {
-    if (in.substr(0, 3) != "uav")
-      std::string();
-    const auto slashpos = in.find("/", 3);
-    if (slashpos == std::string::npos)
-      return in;
-    else
-      return in.substr(0, slashpos);
-  }
-
-  //}
-
-  /* setCurrentControlFrame() //{ */
-
-  void Transformer::setCurrentControlFrame(const std::string& in)
-  {
-
-    std::scoped_lock lock(mutex_current_control_frame_);
-
-    current_control_frame_ = in;
-
-    got_current_control_frame_ = true;
-  }
-
-  //}
-
-  /* setCurrentLatLon() //{ */
-
-  void Transformer::setCurrentLatLon(const double lat, const double lon)
-  {
-
     double utm_x, utm_y;
-
-    {
-      std::scoped_lock lock(mutex_utm_zone_);
-
-      LLtoUTM(lat, lon, utm_y, utm_x, utm_zone_);
-
-      got_utm_zone_ = true;
-    }
+    LLtoUTM(lat, lon, utm_y, utm_x, utm_zone_);
   }
 
   //}
 
-  // | --------------- TransformStamped wrapper ---------------- |
-
-  /* TransformStamped() //{ */
-
-  TransformStamped::TransformStamped()
-  {
-  }
-
-  TransformStamped::TransformStamped(const std::string from_frame, const std::string to_frame, ros::Time stamp)
-  {
-
-    this->from_frame_ = from_frame;
-    this->to_frame_ = to_frame;
-    this->stamp_ = stamp;
-  }
-
-  TransformStamped::TransformStamped(const std::string from_frame, const std::string to_frame, ros::Time stamp,
-                                     const geometry_msgs::TransformStamped transform_stamped)
-  {
-
-    this->from_frame_ = from_frame;
-    this->to_frame_ = to_frame;
-    this->transform_stamped_ = transform_stamped;
-    this->stamp_ = stamp;
-  }
-
-  //}
-
-  /* from() //{ */
-
-  std::string TransformStamped::from(void) const
-  {
-
-    return from_frame_;
-  }
-
-  //}
-
-  /* to() //{ */
-
-  std::string TransformStamped::to(void) const
-  {
-
-    return to_frame_;
-  }
-
-  //}
-
-  /* stamp() //{ */
-
-  ros::Time TransformStamped::stamp(void) const
-  {
-
-    return stamp_;
-  }
-
-  //}
-
-  /* inverse() //{ */
-
-  TransformStamped TransformStamped::inverse(void) const
-  {
-    geometry_msgs::TransformStamped tf = getTransform();
-    tf2::Transform tf2;
-    tf2::fromMsg(tf.transform, tf2);
-    tf2 = tf2.inverse();
-    tf.transform = tf2::toMsg(tf2);
-    std::swap(tf.header.frame_id, tf.child_frame_id);
-    TransformStamped ret(to(), from(), stamp(), tf);
-    return ret;
-  }
-
-  //}
-
-  /* getTransform() //{ */
-
-  geometry_msgs::TransformStamped TransformStamped::getTransform(void) const
-  {
-
-    return transform_stamped_;
-  }
-
-  //}
-
-  /* getTransformEigen() //{ */
-
-  Eigen::Affine3d TransformStamped::getTransformEigen(void) const
-  {
-    return tf2::transformToEigen(getTransform().transform);
-  }
-
-  //}
-  
-  /* getTranslationEigen() //{ */
-
-  Eigen::Vector3d TransformStamped::getTranslationEigen(void) const
-  {
-    auto translation = getTransform().transform.translation;
-    return Eigen::Vector3d(
-        translation.x,
-        translation.y,
-        translation.z
-        );
-  }
-
-  //}
-
-  /* getRotaitonEigen() //{ */
-
-  Eigen::Quaterniond TransformStamped::getRotationEigen(void) const
-  {
-    auto rotation = getTransform().transform.rotation;
-    return Eigen::Quaterniond(
-        rotation.w,
-        rotation.x,
-        rotation.y,
-        rotation.z
-        );
-  }
-
-  //}
-  
-  /* getTransformEigenDecomposed() //{ */
-
-  std::pair<Eigen::Vector3d,Eigen::Quaterniond> TransformStamped::getTransformEigenDecomposed(void) const
-  {
-    return {getTranslationEigen(),getRotationEigen()};
-  }
-
-  //}
-  
 }  // namespace mrs_lib

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -94,13 +94,20 @@ namespace mrs_lib
   {
     if (!initialized_)
     {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot provide transform, not initialized", ros::this_node::getName().c_str());
+      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot provide transform, not initialized!", node_name_.c_str());
       return std::nullopt;
     }
 
     const std::string from_frame = resolveFrame(from_frame_raw);
     const std::string to_frame = resolveFrame(to_frame_raw);
     const std::string latlon_frame = resolveFrame(LATLON_ORIGIN);
+
+    // if any of the frames is empty, then the query is invalid, return nullopt
+    if (from_frame.empty() || to_frame.empty())
+    {
+      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot transform to/from an empty frame!", node_name_.c_str());
+      return std::nullopt;
+    }
 
     // if the frames are the same, just return an identity transform
     if (from_frame == to_frame)
@@ -177,7 +184,7 @@ namespace mrs_lib
   {
     if (!initialized_)
     {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot provide transform, not initialized", ros::this_node::getName().c_str());
+      ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot provide transform, not initialized", node_name_.c_str());
       return std::nullopt;
     }
 
@@ -259,11 +266,16 @@ namespace mrs_lib
 
   std::string Transformer::resolveFrame(const std::string& frame_id)
   {
+    // if the frame is empty, return the default frame id
     if (frame_id.empty())
       return default_frame_id_;
 
+    // if there is no prefix set, just return the raw frame id
+    if (prefix_.empty())
+      return frame_id;
+
     // if there is a default prefix set and the frame does not start with it, prefix it
-    if (!prefix_.empty() && frame_id.substr(0, prefix_.length()) != prefix_)
+    if (frame_id.substr(0, prefix_.length()) != prefix_)
       return prefix_ + frame_id;
 
     return frame_id;

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -2,12 +2,13 @@
 
 #include <mrs_lib/transformer.h>
 #include <mrs_lib/gps_conversions.h>
+#include <mrs_lib/geometry/conversions.h>
 
 using test_t = mrs_msgs::ReferenceStamped;
 /* using test_t = pcl::PointCloud<pcl::PointXYZ>; */
-template std::optional<test_t> mrs_lib::Transformer::transform<test_t>(const mrs_lib::TransformStamped& to_frame, const test_t& what);
-template std::optional<test_t::Ptr> mrs_lib::Transformer::transform<test_t>(const mrs_lib::TransformStamped& to_frame, const test_t::Ptr& what);
-template std::optional<test_t::Ptr> mrs_lib::Transformer::transform<test_t>(const mrs_lib::TransformStamped& to_frame, const test_t::ConstPtr& what);
+template std::optional<test_t> mrs_lib::Transformer::transform<test_t>(const geometry_msgs::TransformStamped& to_frame, const test_t& what);
+template std::optional<test_t::Ptr> mrs_lib::Transformer::transform<test_t>(const geometry_msgs::TransformStamped& to_frame, const test_t::Ptr& what);
+template std::optional<test_t::Ptr> mrs_lib::Transformer::transform<test_t>(const geometry_msgs::TransformStamped& to_frame, const test_t::ConstPtr& what);
 template std::optional<test_t> mrs_lib::Transformer::transformSingle<test_t>(const std::string& to_frame, const test_t& what);
 template std::optional<test_t::Ptr> mrs_lib::Transformer::transformSingle<test_t>(const std::string& to_frame, const test_t::Ptr& what);
 template std::optional<test_t::Ptr> mrs_lib::Transformer::transformSingle<test_t>(const std::string& to_frame, const test_t::ConstPtr& what);
@@ -24,7 +25,7 @@ namespace mrs_lib
   }
 
   Transformer::Transformer(const std::string& node_name)
-    : tf_listener_ptr_(std::make_unique<tf2_ros::TransformListener>(tf_buffer_, node_name)), initialized_(true)
+    : initialized_(true), tf_listener_ptr_(std::make_unique<tf2_ros::TransformListener>(tf_buffer_, node_name)), node_name_(node_name)
   {
   }
 
@@ -32,298 +33,162 @@ namespace mrs_lib
 
   /* transformImpl() //{ */
 
-  std::optional<mrs_msgs::ReferenceStamped> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const mrs_msgs::ReferenceStamped& what)
+  /* specialization for mrs_msgs::ReferenceStamped //{ */
+  
+  std::optional<mrs_msgs::ReferenceStamped> Transformer::transformImpl(const geometry_msgs::TransformStamped& tf, const mrs_msgs::ReferenceStamped& what)
   {
-    const auto tmp_result = prepareMessage(what);
-    const auto result_opt = transformImpl(tf, tmp_result);
-    if (result_opt.has_value())
-      return postprocessMessage(result_opt.value());
-    else
-      return std::nullopt;
-  }
-
-  std::optional<Eigen::Vector3d> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const Eigen::Vector3d& what)
-  {
-    const Eigen::Vector3d output = tf.getTransformEigen().rotation() * what;
-    return output;
-  }
-
-  std::optional<geometry_msgs::PoseStamped> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const geometry_msgs::PoseStamped& what)
-  {
-    geometry_msgs::PoseStamped ret = what;
-    std::string latlon_frame_name = resolveFrameName(LATLON_ORIGIN);
-
-    // check for transformation from LAT-LON GPS
-    if (tf.from() == latlon_frame_name)
-    {
-      // convert LAT-LON to UTM
-      double utm_x, utm_y;
-      mrs_lib::UTM(ret.pose.position.x, ret.pose.position.y, &utm_x, &utm_y);
-
-      // utm_x and utm_y are now in 'utm_origin' frame
-      const std::string uav_prefix = getUAVFramePrefix(tf.from());
-      const std::string utm_frame_name = uav_prefix + "/utm_origin";
-      ret.header.frame_id = utm_frame_name;
-      ret.pose.position.x = utm_x;
-      ret.pose.position.y = utm_y;
-
-      // transform from 'utm_origin' to the desired frame
-      const auto utm_origin_to_end_tf_opt = getTransform(utm_frame_name, tf.to(), tf.stamp());
-      if (!utm_origin_to_end_tf_opt.has_value())
-        return std::nullopt;
-      return doTransform(utm_origin_to_end_tf_opt.value(), ret);
-    }
-    // check for transformation to LAT-LON GPS
-    else if (tf.to() == latlon_frame_name)
-    {
-      // if no UTM zone was specified by the user, we don't know which one to use...
-      if (!got_utm_zone_)
-      {
-        ROS_WARN_THROTTLE(1.0, "[%s]: cannot transform to latlong, missing UTM zone (did you call setCurrentLatLon()?)", node_name_.c_str());
-        return std::nullopt;
-      }
-
-      // first, transform from the desired frame to 'utm_origin'
-      const std::string uav_prefix = getUAVFramePrefix(tf.to());
-      std::string utm_frame_name = uav_prefix + "/utm_origin";
-
-      const auto start_to_utm_origin_tf_opt = getTransform(tf.from(), utm_frame_name, tf.stamp());
-
-      if (!start_to_utm_origin_tf_opt.has_value())
-        return std::nullopt;
-
-      {
-        const auto pose_opt = doTransform(start_to_utm_origin_tf_opt.value(), ret);
-
-        if (!pose_opt.has_value())
-          return std::nullopt;
-
-        ret = std::move(pose_opt.value());
-      }
-
-      // now apply the nonlinear transformation from UTM to LAT-LON
-      {
-        std::scoped_lock lock(mutex_utm_zone_);
-        double lat, lon;
-
-        mrs_lib::UTMtoLL(ret.pose.position.y, ret.pose.position.x, utm_zone_, lat, lon);
-
-        ret.header.frame_id = latlon_frame_name;
-        ret.pose.position.x = lat;
-        ret.pose.position.y = lon;
-
-        return {std::move(ret)};
-      }
-    }
-    // if nothing interesting is requested, just do the plain old linear transformation
-    else
-    {
-      return doTransform(tf, ret);
-    }
-  }
-
-  std::optional<geometry_msgs::Point> Transformer::transformImpl(const mrs_lib::TransformStamped& tf, const geometry_msgs::Point& what)
-  {
-    geometry_msgs::Point ret = what;
-    std::string latlon_frame_name = resolveFrameName(LATLON_ORIGIN);
-
-    // check for transformation from LAT-LON GPS
-    if (tf.from() == latlon_frame_name)
-    {
-      // convert LAT-LON to UTM
-      double utm_x, utm_y;
-      mrs_lib::UTM(ret.x, ret.y, &utm_x, &utm_y);
-
-      // utm_x and utm_y are now in 'utm_origin' frame
-      const std::string uav_prefix = getUAVFramePrefix(tf.from());
-      const std::string utm_frame_name = uav_prefix + "/utm_origin";
-      ret.x = utm_x;
-      ret.y = utm_y;
-
-      // transform from 'utm_origin' to the desired frame
-      const auto utm_origin_to_end_tf_opt = getTransform(utm_frame_name, tf.to(), tf.stamp());
-      if (!utm_origin_to_end_tf_opt.has_value())
-        return std::nullopt;
-      return doTransform(utm_origin_to_end_tf_opt.value(), ret);
-    }
-    // check for transformation to LAT-LON GPS
-    else if (tf.to() == latlon_frame_name)
-    {
-      // if no UTM zone was specified by the user, we don't know which one to use...
-      if (!got_utm_zone_)
-      {
-        ROS_WARN_THROTTLE(1.0, "[%s]: cannot transform to latlong, missing UTM zone (did you call setCurrentLatLon()?)", node_name_.c_str());
-        return std::nullopt;
-      }
-
-      // first, transform from the desired frame to 'utm_origin'
-      const std::string uav_prefix = getUAVFramePrefix(tf.to());
-      std::string utm_frame_name = uav_prefix + "/utm_origin";
-
-      const auto start_to_utm_origin_tf_opt = getTransform(tf.from(), utm_frame_name, tf.stamp());
-
-      if (!start_to_utm_origin_tf_opt.has_value())
-        return std::nullopt;
-
-      {
-        const auto pose_opt = doTransform(start_to_utm_origin_tf_opt.value(), ret);
-
-        if (!pose_opt.has_value())
-          return std::nullopt;
-
-        ret = std::move(pose_opt.value());
-      }
-
-      // now apply the nonlinear transformation from UTM to LAT-LON
-      {
-        std::scoped_lock lock(mutex_utm_zone_);
-        double lat, lon;
-
-        mrs_lib::UTMtoLL(ret.y, ret.x, utm_zone_, lat, lon);
-        ret.x = lat;
-        ret.y = lon;
-
-        return {std::move(ret)};
-      }
-    }
-    // if nothing interesting is requested, just do the plain old linear transformation
-    else
-    {
-      return doTransform(tf, ret);
-    }
-  }
-
-  //}
-
-  /* prepareMessage() //{ */
-
-  geometry_msgs::PoseStamped Transformer::prepareMessage(const mrs_msgs::ReferenceStamped& what)
-  {
-    // create the pose message
+    // create a pose message
     geometry_msgs::PoseStamped pose;
     pose.header = what.header;
-
+  
     pose.pose.position.x = what.reference.position.x;
     pose.pose.position.y = what.reference.position.y;
     pose.pose.position.z = what.reference.position.z;
-
-    pose.pose.orientation = mrs_lib::AttitudeConverter(0, 0, what.reference.heading);
-
-    return pose;
-  }
-
-  //}
-
-  /* postprocessMessage() //{ */
-
-  mrs_msgs::ReferenceStamped Transformer::postprocessMessage(const geometry_msgs::PoseStamped& what)
-  {
-    mrs_msgs::ReferenceStamped ret;
-    ret.header = what.header;
-
-    // copy the new transformed data back
-    ret.reference.position.x = what.pose.position.x;
-    ret.reference.position.y = what.pose.position.y;
-    ret.reference.position.z = what.pose.position.z;
-
-    try
-    {
-      ret.reference.heading = mrs_lib::AttitudeConverter(what.pose.orientation).getHeading();
-    }
-    catch (const mrs_lib::AttitudeConverter::GetHeadingException& e)
-    {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: exception caught while transforming mrs_msgs::Reference's heading: %s", node_name_.c_str(), e.what());
+    pose.pose.orientation = geometry::fromEigen(geometry::quaternionFromHeading(what.reference.heading));
+  
+    // try to transform the pose message
+    const auto pose_opt = transformImpl(tf, pose);
+    if (!pose_opt.has_value())
       return std::nullopt;
-    }
-
+    // overwrite the pose with it's transformed value
+    pose = pose_opt.value();
+  
+    mrs_msgs::ReferenceStamped ret;
+    ret.header = pose.header;
+  
+    // copy the new transformed data back
+    ret.reference.position.x = pose.pose.position.x;
+    ret.reference.position.y = pose.pose.position.y;
+    ret.reference.position.z = pose.pose.position.z;
+    ret.reference.heading = geometry::headingFromRot(geometry::toEigen(pose.pose.orientation));
     return ret;
   }
+  
+  //}
+
+  /* specialization for Eigen::Vector3d //{ */
+  
+  std::optional<Eigen::Vector3d> Transformer::transformImpl(const geometry_msgs::TransformStamped& tf, const Eigen::Vector3d& what)
+  {
+    return tf2::transformToEigen(tf).rotation() * what;
+  }
+  
+  //}
+
+  /* specialization for geometry_msgs::PoseStamped //{ */
+  
+  std::optional<geometry_msgs::PoseStamped> Transformer::transformImpl(const geometry_msgs::TransformStamped& tf, const geometry_msgs::PoseStamped& what)
+  {
+    const std::string from = resolveFrame(frame_from(tf));
+    const std::string to = resolveFrame(frame_to(tf));
+    // if the from frame is the same as the to frame, do nothing
+    if (from == to)
+      return doTransform(tf, what);
+  
+    const std::string latlon_frame_name = resolveFrame(LATLON_ORIGIN);
+  
+    // check for transformation from LAT-LON GPS
+    if (from == latlon_frame_name)
+      return transformFromLatLon(to, tf.header.stamp, getFramePrefix(from), what);
+    // check for transformation to LAT-LON GPS
+    else if (to == latlon_frame_name)
+      return transformToLatLon(from, tf.header.stamp, getFramePrefix(to), what);
+    // if nothing interesting is requested, just do the plain old linear transformation
+    else
+      return doTransform(tf, what);
+  }
+  
+  //}
+
+  /* specialization for geometry_msgs::Point //{ */
+  
+  std::optional<geometry_msgs::Point> Transformer::transformImpl(const geometry_msgs::TransformStamped& tf, const geometry_msgs::Point& what)
+  {
+    const std::string from = resolveFrame(frame_from(tf));
+    const std::string to = resolveFrame(frame_to(tf));
+    // if the from frame is the same as the to frame, do nothing
+    if (from == to)
+      return what;
+  
+    const std::string latlon_frame_name = resolveFrame(LATLON_ORIGIN);
+  
+    // check for transformation from LAT-LON GPS
+    if (from == latlon_frame_name)
+      return transformFromLatLon(to, tf.header.stamp, getFramePrefix(from), what);
+    // check for transformation to LAT-LON GPS
+    else if (to == latlon_frame_name)
+      return transformToLatLon(from, tf.header.stamp, getFramePrefix(to), what);
+    // if nothing interesting is requested, just do the plain old linear transformation
+    else
+      return doTransform(tf, what);
+  }
+  
+  //}
 
   //}
 
   /* getTransform() //{ */
 
-  std::optional<mrs_lib::TransformStamped> Transformer::getTransform(const std::string& from_frame, const std::string& to_frame, const ros::Time& time_stamp,
-                                                                     const bool quiet)
+  std::optional<geometry_msgs::TransformStamped> Transformer::getTransform(const std::string& from_frame_raw, const std::string& to_frame_raw, const ros::Time& time_stamp)
   {
-    if (!is_initialized_)
+    if (!initialized_)
     {
       ROS_ERROR_THROTTLE(1.0, "[%s]: Transformer: cannot provide transform, not initialized", ros::this_node::getName().c_str());
       return std::nullopt;
     }
 
-    const std::string to_frame_resolved = resolveFrameName(to_frame);
-    const std::string from_frame_resolved = resolveFrameName(from_frame);
-    const std::string latlon_frame_resolved = resolveFrameName(LATLON_ORIGIN);
+    const std::string to_frame = resolveFrame(to_frame_raw);
+    const std::string from_frame = resolveFrame(from_frame_raw);
+    const std::string latlon_frame = resolveFrame(LATLON_ORIGIN);
 
-    // check for latlon transform
-    if (from_frame_resolved == latlon_frame_resolved || to_frame_resolved == latlon_frame_resolved)
-      return mrs_lib::TransformStamped(from_frame_resolved, to_frame_resolved, time_stamp);
+    // check for a transform from/to latlon coordinates - that is a special case handled separately
+    if (from_frame == latlon_frame || to_frame == latlon_frame)
+      return create_transform(from_frame, to_frame, time_stamp); // just return an empty transform with the frames
 
+    tf2::TransformException ex("");
     // first try to get transform at the requested time
     try
     {
-      std::scoped_lock lock(mutex_tf_buffer_);
-
-      // get the transform
-      geometry_msgs::TransformStamped transform = tf_buffer_.lookupTransform(to_frame_resolved, from_frame_resolved, time_stamp);
-
-      // return it
-      return mrs_lib::TransformStamped(from_frame_resolved, to_frame_resolved, time_stamp, transform);
+      // try looking up and returning the transform
+      return tf_buffer_.lookupTransform(to_frame, from_frame, time_stamp);
     }
-    catch (tf2::TransformException& ex)
+    catch (tf2::TransformException& e)
     {
-      // this happens often -> DEBUG
-      ROS_DEBUG("[%s]: Transformer: Exception caught while constructing transform from '%s' to '%s': %s", node_name_.c_str(), from_frame_resolved.c_str(),
-                to_frame_resolved.c_str(), ex.what());
+      ex = e;
     }
 
-    // otherwise get the newest one
-    try
+    // if that failed, try to get the newest one if requested
+    if (retry_lookup_newest_)
     {
-      std::scoped_lock lock(mutex_tf_buffer_);
-
-      geometry_msgs::TransformStamped transform = tf_buffer_.lookupTransform(to_frame_resolved, from_frame_resolved, ros::Time(0));
-
-      // return it
-      return mrs_lib::TransformStamped(from_frame_resolved, to_frame_resolved, transform.header.stamp, transform);
-    }
-    catch (tf2::TransformException& ex)
-    {
-      if (quiet)
+      try
       {
-        ROS_DEBUG("[%s]: Transformer: Exception caught while constructing transform from '%s' to '%s': %s", node_name_.c_str(), from_frame_resolved.c_str(),
-                  to_frame_resolved.c_str(), ex.what());
-      } else
-      {
-        ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: Exception caught while constructing transform from '%s' to '%s': %s", node_name_.c_str(),
-                          from_frame_resolved.c_str(), to_frame_resolved.c_str(), ex.what());
+        return tf_buffer_.lookupTransform(to_frame, from_frame, ros::Time(0));
       }
+      catch (tf2::TransformException& e)
+      {
+        ex = e;
+      }
+    }
+
+    // if the flow got here, we've failed to look the transform up
+    if (quiet_)
+    {
+      ROS_DEBUG("[%s]: Transformer: Exception caught while constructing transform from '%s' to '%s': %s", node_name_.c_str(), from_frame.c_str(),
+                to_frame.c_str(), ex.what());
+    } else
+    {
+      ROS_WARN_THROTTLE(1.0, "[%s]: Transformer: Exception caught while constructing transform from '%s' to '%s': %s", node_name_.c_str(),
+                        from_frame.c_str(), to_frame.c_str(), ex.what());
     }
 
     return std::nullopt;
   }
 
-  /* bool Transformer::getTransform(const std::string& from_frame, const std::string& to_frame, const ros::Time& time_stamp, mrs_lib::TransformStamped& output)
-   */
-  /* { */
-  /*   const auto result_opt = getTransform(from_frame, to_frame, time_stamp); */
-  /*   if (result_opt.has_value()) */
-  /*   { */
-  /*     output = result_opt.value(); */
-  /*     return true; */
-  /*   } */
-  /*   else */
-  /*   { */
-  /*     return false; */
-  /*   } */
-  /* } */
-
   //}
 
-  /* resolve_frame() //{ */
+  /* resolveFrame() //{ */
 
-  std::string Transformer::resolve_frame(const std::string& frame_id)
+  std::string Transformer::resolveFrame(const std::string& frame_id)
   {
     if (frame_id.empty())
       return default_frame_id_;
@@ -337,14 +202,69 @@ namespace mrs_lib
 
   //}
 
-  /* set_lat_lon() //{ */
+  /* setLatLon() //{ */
 
-  void set_lat_lon(const double lat, const double lon)
+  void Transformer::setLatLon(const double lat, const double lon)
   {
     double utm_x, utm_y;
     LLtoUTM(lat, lon, utm_y, utm_x, utm_zone_);
   }
 
   //}
+
+  /* transformFromLatLon() method //{ */
+  std::optional<Eigen::Vector3d> Transformer::transformFromLatLon(const std::string& to_frame, const ros::Time& at_time, const std::string& uav_prefix, const Eigen::Vector3d& what)
+  {
+    // convert LAT-LON to UTM
+    Eigen::Vector3d utm;
+    mrs_lib::UTM(what.x(), what.y(), &(utm.x()), &(utm.y()));
+    // copy the height from the input
+    utm.z() = what.z();
+  
+    // utm_x and utm_y are now in 'utm_origin' frame
+    const std::string utm_frame_name = uav_prefix + "utm_origin";
+  
+    // transform from 'utm_origin' to the desired frame
+    const auto utm_origin_to_end_tf_opt = getTransform(utm_frame_name, to_frame, at_time);
+    if (!utm_origin_to_end_tf_opt.has_value())
+      return std::nullopt;
+    return doTransform(utm_origin_to_end_tf_opt.value(), utm);
+  }
+  //}
+
+  /* transformToLatLon() method //{ */
+  std::optional<Eigen::Vector3d> Transformer::transformToLatLon(const std::string& from_frame, const ros::Time& at_time, const std::string& uav_prefix, const Eigen::Vector3d& what)
+  {
+    // if no UTM zone was specified by the user, we don't know which one to use...
+    if (!got_utm_zone_)
+    {
+      ROS_WARN_THROTTLE(1.0, "[%s]: cannot transform to latlong, missing UTM zone (did you call setLatLon()?)", node_name_.c_str());
+      return std::nullopt;
+    }
+  
+    // first, transform from the desired frame to 'utm_origin'
+    const std::string utm_frame_name = uav_prefix + "utm_origin";
+    const auto start_to_utm_origin_tf_opt = getTransform(from_frame, utm_frame_name, at_time);
+  
+    if (!start_to_utm_origin_tf_opt.has_value())
+      return std::nullopt;
+  
+    const std::optional<Eigen::Vector3d> utm = doTransform(start_to_utm_origin_tf_opt.value(), what);
+    if (!utm.has_value())
+      return std::nullopt;
+  
+    // now apply the nonlinear transformation from UTM to LAT-LON
+    Eigen::Vector3d latlon;
+    mrs_lib::UTMtoLL(utm->y(), utm->x(), utm_zone_, latlon.x(), latlon.y());
+    latlon.z() = utm->z();
+  
+    return latlon;
+  }
+  //}
+
+  std::string getFramePrefix(const std::string& frame_id)
+  {
+    return frame_id.substr(0, frame_id.find_first_of('/'));
+  }
 
 }  // namespace mrs_lib

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -24,8 +24,8 @@ namespace mrs_lib
   {
   }
 
-  Transformer::Transformer(const std::string& node_name)
-    : initialized_(true), node_name_(node_name), tf_listener_ptr_(std::make_unique<tf2_ros::TransformListener>(tf_buffer_, node_name))
+  Transformer::Transformer(const ros::NodeHandle& nh, const std::string& node_name)
+    : initialized_(true), node_name_(node_name), tf_listener_ptr_(std::make_unique<tf2_ros::TransformListener>(tf_buffer_, nh))
   {
   }
 

--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -110,7 +110,7 @@ namespace mrs_lib
     if (from_frame == latlon_frame)
     {
       // find the transformation between the UTM frame and the non-latlon frame to fill the returned tf
-      const std::string utm_frame = getFramePrefix(from_frame) + "/utm_origin";
+      const std::string utm_frame = getFramePrefix(from_frame) + "utm_origin";
       auto tf_opt = getTransform(utm_frame, to_frame, time_stamp);
       if (!tf_opt.has_value())
         return std::nullopt;
@@ -121,7 +121,7 @@ namespace mrs_lib
     else if (to_frame == latlon_frame)
     {
       // find the transformation between the UTM frame and the non-latlon frame to fill the returned tf
-      const std::string utm_frame = getFramePrefix(to_frame) + "/utm_origin";
+      const std::string utm_frame = getFramePrefix(to_frame) + "utm_origin";
       auto tf_opt = getTransform(from_frame, utm_frame, time_stamp);
       if (!tf_opt.has_value())
         return std::nullopt;
@@ -194,7 +194,7 @@ namespace mrs_lib
     if (from_frame == latlon_frame)
     {
       // find the transformation between the UTM frame and the non-latlon frame to fill the returned tf
-      const std::string utm_frame = getFramePrefix(from_frame) + "/utm_origin";
+      const std::string utm_frame = getFramePrefix(from_frame) + "utm_origin";
       auto tf_opt = getTransform(utm_frame, from_stamp, to_frame, to_stamp, fixed_frame);
       if (!tf_opt.has_value())
         return std::nullopt;
@@ -205,7 +205,7 @@ namespace mrs_lib
     else if (to_frame == latlon_frame)
     {
       // find the transformation between the UTM frame and the non-latlon frame to fill the returned tf
-      const std::string utm_frame = getFramePrefix(to_frame) + "/utm_origin";
+      const std::string utm_frame = getFramePrefix(to_frame) + "utm_origin";
       auto tf_opt = getTransform(from_frame, from_stamp, utm_frame, to_stamp, fixed_frame);
       if (!tf_opt.has_value())
         return std::nullopt;
@@ -264,7 +264,7 @@ namespace mrs_lib
 
     // if there is a default prefix set and the frame does not start with it, prefix it
     if (!prefix_.empty() && frame_id.substr(0, prefix_.length()) != prefix_)
-      return prefix_ + "/" + frame_id;
+      return prefix_ + frame_id;
 
     return frame_id;
   }
@@ -304,7 +304,7 @@ namespace mrs_lib
   geometry_msgs::PoseStamped Transformer::LLtoUTM(const geometry_msgs::PoseStamped& what, const std::string& prefix)
   {
     geometry_msgs::PoseStamped ret;
-    ret.header.frame_id = prefix + "/utm_origin";
+    ret.header.frame_id = prefix + "utm_origin";
     ret.header.stamp = what.header.stamp;
     ret.pose = LLtoUTM(what.pose, prefix);
     return ret;
@@ -347,7 +347,7 @@ namespace mrs_lib
       return std::nullopt;
 
     geometry_msgs::PoseStamped ret;
-    ret.header.frame_id = prefix + "/utm_origin";
+    ret.header.frame_id = prefix + "utm_origin";
     ret.header.stamp = what.header.stamp;
     ret.pose = opt.value();
     return ret;
@@ -357,7 +357,11 @@ namespace mrs_lib
   /* getFramePrefix() method //{ */
   std::string Transformer::getFramePrefix(const std::string& frame_id)
   {
-    return frame_id.substr(0, frame_id.find_first_of('/'));
+    const auto firstof = frame_id.find_first_of('/');
+    if (firstof == std::string::npos)
+      return "";
+    else
+      return frame_id.substr(0, firstof+1);
   }
   //}
 

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,7 +6,7 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 trap 'echo "$0: \"${last_command}\" command failed with exit code $?"' ERR
 
 PACKAGE="mrs_lib"
-VERBOSE=1
+VERBOSE=0
 
 [ "$VERBOSE" = "0" ] && TEXT_OUTPUT=""
 [ "$VERBOSE" = "1" ] && TEXT_OUTPUT="-t"

--- a/test/run_tests.sh
+++ b/test/run_tests.sh
@@ -6,7 +6,7 @@ trap 'last_command=$current_command; current_command=$BASH_COMMAND' DEBUG
 trap 'echo "$0: \"${last_command}\" command failed with exit code $?"' ERR
 
 PACKAGE="mrs_lib"
-VERBOSE=0
+VERBOSE=1
 
 [ "$VERBOSE" = "0" ] && TEXT_OUTPUT=""
 [ "$VERBOSE" = "1" ] && TEXT_OUTPUT="-t"

--- a/test/transformer/test.cpp
+++ b/test/transformer/test.cpp
@@ -357,10 +357,7 @@ TEST(TESTSuite, latlon_test)
     std::cout << "from: " << Transformer::frame_from(tf) << ", to: " << Transformer::frame_to(tf) << ", stamp: " << tf.header.stamp << std::endl;
     std::cout << tf << std::endl;
 
-    geometry_msgs::Point tv;
-    tv.x = 5;
-    tv.y = 6;
-    tv.z = 7;
+    const vec3_t tv(5, 6, 7);
     const auto rv = tfr.transform(tf, tv);
     if (!rv)
     {

--- a/test/transformer/test.cpp
+++ b/test/transformer/test.cpp
@@ -24,6 +24,7 @@ Eigen::Affine3d local2utm;
 Eigen::Affine3d fcu2cam;
 std::unique_ptr<tf2_ros::TransformBroadcaster> bc;
 
+//{ publish_transform helper function
 void publish_transforms(const ros::Time& t = ros::Time::now())
 {
   geometry_msgs::TransformStamped tf;
@@ -56,7 +57,9 @@ void publish_transforms(const ros::Time& t = ros::Time::now())
   bc->sendTransform(tf);
   ros::spinOnce();
 }
+//}
 
+/* //{ wait_for_tf helper function*/
 std::optional<geometry_msgs::TransformStamped> wait_for_tf(const std::string& from, const std::string& to, mrs_lib::Transformer& tfr, const ros::Time& publish_t = ros::Time::now(), const ros::Time& stamp = ros::Time(0))
 {
   std::cout << "Waiting for transformation from " << from << " to " << to << ".\n";
@@ -75,6 +78,7 @@ std::optional<geometry_msgs::TransformStamped> wait_for_tf(const std::string& fr
   }
   return tf_opt;
 }
+//}
 
 /* TEST(TESTSuite, main_test) //{ */
 
@@ -84,7 +88,7 @@ TEST(TESTSuite, main_test)
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_main_test");
   tfr.setDefaultPrefix("uav66");
 
   const std::string from = "fcu";
@@ -145,7 +149,7 @@ TEST(TESTSuite, tf_times_test)
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_tf_times_test");
 
   const ros::Time t1 = ros::Time(1);
   const std::string from = "uav1/fcu";
@@ -232,13 +236,14 @@ TEST(TESTSuite, tf_times_test)
 
 /* TEST(TESTSuite, eigen_vector3d_test) //{ */
 
-TEST(TESTSuite, eigen_vector3d_test) {
+TEST(TESTSuite, eigen_vector3d_test)
+{
 
   ROS_INFO("[%s]: Testing the Eigen::Vector3d transformation", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_eigen_vector3d_test");
   tfr.setDefaultPrefix("uav66");
 
   publish_transforms();
@@ -289,13 +294,14 @@ TEST(TESTSuite, eigen_vector3d_test) {
 
 /* TEST(TESTSuite, transform_single) //{ */
 
-TEST(TESTSuite, transform_single) {
+TEST(TESTSuite, transform_single)
+{
 
   ROS_INFO("[%s]: Testing transformSingle", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_transform_single");
   tfr.setDefaultPrefix("uav66");
 
   const ros::Time t = ros::Time::now();
@@ -371,13 +377,14 @@ TEST(TESTSuite, transform_single) {
 
 /* TEST(TESTSuite, mrs_reference_test) //{ */
 
-TEST(TESTSuite, mrs_reference_test) {
+TEST(TESTSuite, mrs_reference_test)
+{
 
   ROS_INFO("[%s]: Testing the mrs_msgs::ReferenceStamped transformation", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_mrs_reference_test");
   tfr.setDefaultPrefix("uav66");
 
   publish_transforms();
@@ -455,7 +462,7 @@ TEST(TESTSuite, quaternion_test)
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_quaternion_test");
   tfr.setDefaultPrefix("uav66");
 
   publish_transforms();
@@ -606,7 +613,7 @@ TEST(TESTSuite, latlon_test)
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_latlon_test");
   tfr.setDefaultPrefix("uav66");
 
   publish_transforms();
@@ -654,13 +661,14 @@ TEST(TESTSuite, latlon_test)
 
 /* TEST(TESTSuite, eigen_decomposed_test) //{ */
 
-TEST(TESTSuite, eigen_decomposed_test) {
+TEST(TESTSuite, eigen_decomposed_test)
+{
 
   ROS_INFO("[%s]: Testing the Eigen translation and rotation extraction", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_eigen_decomposed_test");
   tfr.setDefaultPrefix("uav66");
 
   publish_transforms();
@@ -717,13 +725,14 @@ TEST(TESTSuite, eigen_decomposed_test) {
 
 /* TEST(TESTSuite, retry_latest_test) //{ */
 
-TEST(TESTSuite, retry_latest_test) {
+TEST(TESTSuite, retry_latest_test)
+{
 
   ROS_INFO("[%s]: Testing the functionality of retrying with latest time in case of failure", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_retry_latest_test");
   tfr.setDefaultPrefix("uav66");
 
   const ros::Time t = ros::Time::now();
@@ -759,11 +768,11 @@ TEST(TESTSuite, retry_latest_test) {
 TEST(TESTSuite, prefix_test)
 {
 
-  ROS_INFO("[%s]: Testing the functionality of retrying with latest time in case of failure", ros::this_node::getName().c_str());
+  ROS_INFO("[%s]: Testing the functionality of default prefix", ros::this_node::getName().c_str());
 
   int result = 1;
 
-  auto tfr = mrs_lib::Transformer("TransformerTest");
+  auto tfr = mrs_lib::Transformer("Transformer_prefix_test");
 
   const ros::Time t = ros::Time::now();
   publish_transforms(t);
@@ -806,6 +815,60 @@ TEST(TESTSuite, prefix_test)
   if (tf_opt.has_value())
   {
     ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
+/* TEST(TESTSuite, empty_frame_test) //{ */
+
+TEST(TESTSuite, default_frame_test)
+{
+
+  ROS_INFO("[%s]: Testing the functionality of default frame name", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("Transformer_default_frame_test");
+  tfr.setDefaultPrefix("uav66");
+  tfr.setLookupTimeout(ros::Duration(0.1));
+
+  const ros::Time t = ros::Time::now();
+  publish_transforms(t);
+
+  auto tf_opt = tfr.getTransform("camera", "");
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  tf_opt = std::nullopt;
+  tf_opt = tfr.getTransform("", "fcu");
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  tf_opt = std::nullopt;
+  tf_opt = tfr.getTransform("", "");
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  ROS_INFO("[%s]: Setting the default frame name", ros::this_node::getName().c_str());
+  tfr.setDefaultFrame("uav66/fcu");
+  tf_opt = std::nullopt;
+  tf_opt = tfr.getTransform("", "");
+  if (!tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "didn't get the transformation!");
     result *= 0;
   }
 

--- a/test/transformer/test.cpp
+++ b/test/transformer/test.cpp
@@ -1,7 +1,11 @@
 #include <mrs_lib/transformer.h>
 #include <mrs_lib/geometry/conversions.h>
 #include <mrs_lib/attitude_converter.h>
+#include <tf2_ros/transform_broadcaster.h>
 #include <geometry_msgs/PointStamped.h>
+#include <geometry_msgs/Quaternion.h>
+
+#include <tf2_eigen/tf2_eigen.h>
 
 #include <cmath>
 #include <iostream>
@@ -11,28 +15,80 @@
 
 using namespace mrs_lib;
 using namespace std;
+using namespace mrs_lib::geometry;
+
+Eigen::Affine3d local2local;
+Eigen::Affine3d local2fcu;
+Eigen::Affine3d local2utm;
+Eigen::Affine3d fcu2cam;
+std::unique_ptr<tf2_ros::TransformBroadcaster> bc;
+
+void publish_transforms(const ros::Time& t = ros::Time::now())
+{
+  geometry_msgs::TransformStamped tf;
+
+  tf = tf2::eigenToTransform(local2local);
+  tf.header.frame_id = "uav3/local_origin";
+  tf.header.stamp = t;
+  tf.child_frame_id = "uav66/local_origin";
+  bc->sendTransform(tf);
+  ros::spinOnce();
+
+  tf = tf2::eigenToTransform(local2fcu);
+  tf.header.frame_id = "uav66/local_origin";
+  tf.header.stamp = t;
+  tf.child_frame_id = "uav66/fcu";
+  bc->sendTransform(tf);
+  ros::spinOnce();
+
+  tf = tf2::eigenToTransform(local2utm);
+  tf.header.frame_id = "uav66/local_origin";
+  tf.header.stamp = t;
+  tf.child_frame_id = "uav66/utm_origin";
+  bc->sendTransform(tf);
+  ros::spinOnce();
+
+  tf = tf2::eigenToTransform(fcu2cam);
+  tf.header.frame_id = "uav66/fcu";
+  tf.header.stamp = t;
+  tf.child_frame_id = "uav66/camera";
+  bc->sendTransform(tf);
+  ros::spinOnce();
+}
+
+std::optional<geometry_msgs::TransformStamped> wait_for_tf(const std::string& from, const std::string& to, mrs_lib::Transformer& tfr, const ros::Time& publish_t = ros::Time::now(), const ros::Time& stamp = ros::Time(0))
+{
+  std::cout << "Waiting for transformation from " << from << " to " << to << ".\n";
+  std::optional<geometry_msgs::TransformStamped> tf_opt;
+  // get the transform
+  for (int it = 0; it < 20 && ros::ok(); it++)
+  {
+    publish_transforms(publish_t);
+    ros::spinOnce();
+    tf_opt = tfr.getTransform(from, to, stamp);
+
+    if (tf_opt.has_value())
+      break;
+
+    ros::Duration(0.1).sleep();
+  }
+  return tf_opt;
+}
 
 /* TEST(TESTSuite, main_test) //{ */
 
-TEST(TESTSuite, main_test) {
+TEST(TESTSuite, main_test)
+{
+  std::cout << "Running main_test\n";
 
   int result = 1;
 
   auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
 
-  std::optional<geometry_msgs::TransformStamped> tf_opt;
-
-  // get the transform
-  for (int it = 0; it < 1000 && ros::ok(); it++) {
-
-    tf_opt = tfr.getTransform("local_origin", "fcu");
-
-    if (tf_opt.has_value()) {
-      break;
-    }
-
-    ros::Duration(0.1).sleep();
-  }
+  const std::string from = "fcu";
+  const std::string to = "local_origin";
+  const auto tf_opt = wait_for_tf(from, to, tfr);
 
   if (tf_opt.has_value()) {
 
@@ -46,20 +102,18 @@ TEST(TESTSuite, main_test) {
     std::cout << "from: " << Transformer::frame_from(tf_inv) << ", to: " << Transformer::frame_to(tf_inv) << ", stamp: " << tf_inv.header.stamp << std::endl;
     std::cout << tf_inv << std::endl;
 
-    if (fabs(tf_inv.transform.translation.x - 1) > 1e-6 || fabs(tf_inv.transform.translation.y - 2) > 1e-6 ||
-        fabs(tf_inv.transform.translation.z - 3) > 1e-6) {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: translation does not match", ros::this_node::getName().c_str());
+    if (fabs(tf_inv.transform.translation.x - local2fcu.translation().x()) > 1e-6 || fabs(tf_inv.transform.translation.y - local2fcu.translation().y()) > 1e-6 ||
+        fabs(tf_inv.transform.translation.z - local2fcu.translation().z()) > 1e-6) {
+      ROS_ERROR_STREAM_THROTTLE(1.0, "translation does not match (gt: " << local2fcu.translation().transpose() << ")");
       result *= 0;
     }
 
-    auto [r, p, y] = mrs_lib::AttitudeConverter(tf_inv.transform.rotation).getIntrinsicRPY();
+    const Eigen::Isometry3d etf = tf2::transformToEigen(tf_inv);
+    const quat_t etf_rot(etf.rotation());
+    const double angle_diff = etf_rot.angularDistance(quat_t(local2fcu.rotation()));
 
-    ROS_INFO("[%s]: r: %.2f", ros::this_node::getName().c_str(), r);
-    ROS_INFO("[%s]: p: %.2f", ros::this_node::getName().c_str(), p);
-    ROS_INFO("[%s]: y: %.2f", ros::this_node::getName().c_str(), y);
-
-    if (fabs(r - 1) > 1e-6 || fabs(p - 1.57) > 1e-6 || fabs(y - 2) > 1e-6) {
-      ROS_ERROR_THROTTLE(1.0, "[%s]: rotation does not match", ros::this_node::getName().c_str());
+    if (angle_diff > 1e-6) {
+      ROS_ERROR_STREAM_THROTTLE(1.0, "translation does not match (by angle: " << angle_diff << ")");
       result *= 0;
     }
 
@@ -82,20 +136,13 @@ TEST(TESTSuite, eigen_vector3d_test) {
   int result = 1;
 
   auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
 
-  std::optional<geometry_msgs::TransformStamped> tf_opt;
+  publish_transforms();
 
-  // get the transform
-  for (int it = 0; it < 1000 && ros::ok(); it++) {
-
-    tf_opt = tfr.getTransform("camera", "fcu");
-
-    if (tf_opt.has_value()) {
-      break;
-    }
-
-    ros::Duration(0.1).sleep();
-  }
+  const std::string from = "uav66/camera";
+  const std::string to = "fcu";
+  const auto tf_opt = wait_for_tf(from, to, tfr);
 
   if (tf_opt.has_value()) {
 
@@ -105,18 +152,23 @@ TEST(TESTSuite, eigen_vector3d_test) {
     std::cout << "from: " << Transformer::frame_from(tf) << ", to: " << Transformer::frame_to(tf) << ", stamp: " << tf.header.stamp << std::endl;
     std::cout << tf << std::endl;
 
-    std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> test_vectors = {{{1, 0, 0}, {0, -1, 0}}, {{0, 1, 0}, {0, 0, -1}}, {{0, 0, 1}, {1, 0, 0}}};
+    std::vector<Eigen::Vector3d> test_vectors = {{1, 0, 0}, {0, -1, 666}, {0, 0, 0}, {0, 1.1, -1}, {0, 0, 18}, {3, 0, 0}};
 
     for (const auto& tv : test_vectors) {
-      const auto rv = tfr.transform(tf, tv.first);
-      if (!rv) {
-        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv.first.transpose() << "]");
+      const auto rv = tfr.transform(tf, tv);
+      if (!rv)
+      {
+        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv.transpose() << "]");
         result *= 0;
-      } else {
-        Eigen::Vector3d vect_diff = rv.value() - tv.second;
-        if (vect_diff.norm() > 1e-6) {
-          ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated vector [" << tv.first.transpose() << "] with value of ["
-                                             << rv.value().transpose() << "] does not match the expected value of [" << tv.second.transpose() << "]");
+      }
+      else
+      {
+        const vec3_t gt = fcu2cam.inverse()*tv;
+        const vec3_t vect_diff = rv.value() - gt;
+        if (vect_diff.norm() > 1e-6)
+        {
+          ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated vector [" << gt.transpose() << "] with value of ["
+                                             << rv.value().transpose() << "] does not match the expected value of [" << gt.transpose() << "]");
           result *= 0;
         }
       }
@@ -141,20 +193,13 @@ TEST(TESTSuite, mrs_reference_test) {
   int result = 1;
 
   auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
 
-  std::optional<geometry_msgs::TransformStamped> tf_opt;
+  publish_transforms();
 
-  // get the transform
-  for (int it = 0; it < 1000 && ros::ok(); it++) {
-
-    tf_opt = tfr.getTransform("camera", "fcu");
-
-    if (tf_opt.has_value()) {
-      break;
-    }
-
-    ros::Duration(0.1).sleep();
-  }
+  const std::string from = "uav66/fcu";
+  const std::string to = "camera";
+  const auto tf_opt = wait_for_tf(from, to, tfr);
 
   if (tf_opt.has_value()) {
 
@@ -164,30 +209,31 @@ TEST(TESTSuite, mrs_reference_test) {
     std::cout << "from: " << Transformer::frame_from(tf) << ", to: " << Transformer::frame_to(tf) << ", stamp: " << tf.header.stamp << std::endl;
     std::cout << tf << std::endl;
 
-    const std::vector<std::pair<Eigen::Vector3d, Eigen::Vector3d>> test_vectors = {{{1, 0, 0}, {0, -1, 0}}, {{0, 1, 0}, {0, 0, -1}}, {{0, 0, 1}, {1, 0, 0}}};
+    const std::vector<Eigen::Vector3d> test_vectors = {{1, 0, 0}, {0, -1, 666}, {0, 0, 0}, {0, 1.1, -1}, {0, 0, 18}, {3, 0, 0}};
     std::vector<std::pair<mrs_msgs::ReferenceStamped, mrs_msgs::ReferenceStamped>> test_refs;
     mrs_msgs::ReferenceStamped orig, tfd;
     orig.header.frame_id = "camera";
     orig.header.stamp = ros::Time::now();
     tfd.header.frame_id = "fcu";
     tfd.header.stamp = orig.header.stamp;
-    for (const auto& vecs : test_vectors)
+    for (const auto& vec : test_vectors)
     {
-      orig.reference.position.x = vecs.first.x();
-      orig.reference.position.y = vecs.first.y();
-      orig.reference.position.z = vecs.first.z();
-      orig.reference.heading = std::atan2(vecs.first.y(), vecs.first.z());
+      orig.reference.position.x = vec.x();
+      orig.reference.position.y = vec.y();
+      orig.reference.position.z = vec.z();
+      orig.reference.heading = std::atan2(vec.y(), vec.z());
 
-      tfd.reference.position.x = vecs.second.x();
-      tfd.reference.position.y = vecs.second.y();
-      tfd.reference.position.z = vecs.second.z();
-      tfd.reference.heading = std::atan2(vecs.second.y(), vecs.second.z());
+      const vec3_t gt = fcu2cam*vec;
+      tfd.reference.position.x = gt.x();
+      tfd.reference.position.y = gt.y();
+      tfd.reference.position.z = gt.z();
+      tfd.reference.heading = headingFromRot(fcu2cam.rotation()*quaternionFromHeading(orig.reference.heading));
 
       test_refs.push_back({orig, tfd});
     }
 
     for (const auto& tv : test_refs) {
-      const auto rv_opt = tfr.transformSingle("fcu", tv.first);
+      const auto rv_opt = tfr.transform(tf, tv.first);
       if (!rv_opt) {
         ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform reference [" << tv.first << "]");
         result *= 0;
@@ -215,6 +261,127 @@ TEST(TESTSuite, mrs_reference_test) {
 
 //}
 
+/* TEST(TESTSuite, quaternion_test) //{ */
+
+TEST(TESTSuite, quaternion_test)
+{
+
+  ROS_INFO("[%s]: Testing the geometry_msgs::Quaternion transformation", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
+
+  publish_transforms();
+
+  const std::string from = "local_origin";
+  const std::string to = "fcu";
+  const auto tf_opt = wait_for_tf(from, to, tfr);
+
+  if (tf_opt.has_value())
+  {
+    ROS_INFO("[%s]: got the transform", ros::this_node::getName().c_str());
+
+    const auto tf = tf_opt.value();
+    std::cout << "from: " << Transformer::frame_from(tf) << ", to: " << Transformer::frame_to(tf) << ", stamp: " << tf.header.stamp << std::endl;
+    std::cout << tf << std::endl;
+
+    std::vector<geometry_msgs::Quaternion> tsts;
+    tsts.push_back(tf2::toMsg(quat_t::UnitRandom()));
+    tsts.push_back(tf2::toMsg(quat_t::UnitRandom()));
+    tsts.push_back(tf2::toMsg(quat_t::UnitRandom()));
+    tsts.push_back(tf2::toMsg(quat_t::UnitRandom()));
+    tsts.push_back(tf2::toMsg(quat_t::UnitRandom()));
+
+    for (const auto& tv : tsts)
+    {
+      const auto rv = tfr.transform(tf, tv);
+      if (!rv)
+      {
+        ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform quaternion [" << tv << "]");
+        result *= 0;
+      }
+      else
+      {
+        quat_t orig, tfd;
+        tf2::fromMsg(tv, orig);
+        tf2::fromMsg(rv.value(), tfd);
+        const quat_t gt(local2fcu.rotation()*orig);
+        const double angle_diff = gt.angularDistance(tfd);
+        if (angle_diff > 1e-6)
+        {
+          ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotated quaternion [" << tv << "] with value of ["
+                                             << rv.value() << "] does not match the expected value of [" << tf2::toMsg(gt) << "]");
+          result *= 0;
+        }
+      }
+    }
+
+  }
+  else
+  {
+    ROS_ERROR_THROTTLE(1.0, "[%s]: missing tf", ros::this_node::getName().c_str());
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
+/* TEST(TESTSuite, latlon_test) //{ */
+
+TEST(TESTSuite, latlon_test)
+{
+
+  ROS_INFO("[%s]: Testing transformation from/to latlon", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
+  tfr.setLatLon(0, 0);
+
+  publish_transforms();
+
+  const std::string from = "local_origin";
+  const std::string to = mrs_lib::LATLON_ORIGIN;
+  const auto tf_opt = wait_for_tf(from, to, tfr);
+
+  if (tf_opt.has_value())
+  {
+    ROS_INFO("[%s]: got the transform", ros::this_node::getName().c_str());
+
+    const auto tf = tf_opt.value();
+    std::cout << "from: " << Transformer::frame_from(tf) << ", to: " << Transformer::frame_to(tf) << ", stamp: " << tf.header.stamp << std::endl;
+    std::cout << tf << std::endl;
+
+    geometry_msgs::Point tv;
+    tv.x = 5;
+    tv.y = 6;
+    tv.z = 7;
+    const auto rv = tfr.transform(tf, tv);
+    if (!rv)
+    {
+      ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: Failed to transform vector [" << tv << "]");
+      result *= 0;
+    }
+    else
+    {
+    }
+  }
+  else
+  {
+    ROS_ERROR_THROTTLE(1.0, "[%s]: missing tf", ros::this_node::getName().c_str());
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
 /* TEST(TESTSuite, eigen_decomposed_test) //{ */
 
 TEST(TESTSuite, eigen_decomposed_test) {
@@ -224,20 +391,13 @@ TEST(TESTSuite, eigen_decomposed_test) {
   int result = 1;
 
   auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
 
-  std::optional<geometry_msgs::TransformStamped> tf_opt;
+  publish_transforms();
 
-  // get the transform
-  for (int it = 0; it < 1000 && ros::ok(); it++) {
-
-    tf_opt = tfr.getTransform("camera", "fcu");
-
-    if (tf_opt.has_value()) {
-      break;
-    }
-
-    ros::Duration(0.1).sleep();
-  }
+  const std::string from = "camera";
+  const std::string to = "fcu";
+  const auto tf_opt = wait_for_tf(from, to, tfr);
 
   if (tf_opt.has_value()) {
 
@@ -253,23 +413,19 @@ TEST(TESTSuite, eigen_decomposed_test) {
     const Eigen::Vector3d tran = etf.translation();
     const Eigen::Quaterniond rot(etf.rotation());
 
-    Eigen::Vector3d tran_template = {1.0,2.0,3.0};
-    Eigen::Vector3d vect_diff = tran - tran_template;
+    const vec3_t gt = fcu2cam.inverse().translation();
+    const vec3_t vect_diff = tran - gt;
     if (vect_diff.norm() > 1e-6) {
       ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: translation vector \
           [" << tran.transpose() << "]\
           does not match the expected value of \
-          [" << tran_template.transpose() << "]");
+          [" << gt.transpose() << "]");
       result *= 0;
     }
 
-    Eigen::Matrix3d rot_mat_template;
-    rot_mat_template <<
-        0.0,  0.0, 1.0, \
-       -1.0,  0.0, 0.0, \
-        0.0, -1.0, 0.0;
-    Eigen::Quaterniond rot_template(rot_mat_template);
-    if (rot_template.angularDistance(rot) > 1e-6) {
+    const quat_t rot_template(fcu2cam.inverse().rotation());
+    if (rot_template.angularDistance(rot) > 1e-6)
+    {
       ROS_ERROR_STREAM_THROTTLE(1.0, "[" << ros::this_node::getName() << "]: rotation quaternion \
           [" << rot.x() << "," << rot.y() << "," << rot.z() << "," << rot.w() << "]\
           does not match the expected value of \
@@ -277,8 +433,109 @@ TEST(TESTSuite, eigen_decomposed_test) {
       result *= 0;
     }
 
-  } else {
+  }
+  else
+  {
     ROS_ERROR_THROTTLE(1.0, "[%s]: missing tf", ros::this_node::getName().c_str());
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
+/* TEST(TESTSuite, retry_latest_test) //{ */
+
+TEST(TESTSuite, retry_latest_test) {
+
+  ROS_INFO("[%s]: Testing the functionality of retrying with latest time in case of failure", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("TransformerTest");
+  tfr.setDefaultPrefix("uav66");
+
+  const ros::Time t = ros::Time::now();
+  publish_transforms(t);
+
+  const std::string from = "camera";
+  const std::string to = "local_origin";
+  auto tf_opt = wait_for_tf(from, to, tfr, t, t - ros::Duration(1000));
+
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  tf_opt = std::nullopt;
+  tfr.retryLookupNewest(true);
+  tf_opt = wait_for_tf(from, to, tfr, t, t - ros::Duration(1000));
+
+  if (!tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "didn't get the transformation!");
+    result *= 0;
+  }
+
+  EXPECT_TRUE(result);
+}
+
+//}
+
+/* TEST(TESTSuite, prefix_test) //{ */
+
+TEST(TESTSuite, prefix_test)
+{
+
+  ROS_INFO("[%s]: Testing the functionality of retrying with latest time in case of failure", ros::this_node::getName().c_str());
+
+  int result = 1;
+
+  auto tfr = mrs_lib::Transformer("TransformerTest");
+
+  const ros::Time t = ros::Time::now();
+  publish_transforms(t);
+
+  auto tf_opt = wait_for_tf("camera", "local_origin", tfr);
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
+    result *= 0;
+  }
+
+  tf_opt = std::nullopt;
+  tf_opt = wait_for_tf("uav3/local_origin", "uav66/local_origin", tfr);
+  if (!tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "didn't get the transformation!");
+    result *= 0;
+  }
+
+  tfr.setDefaultPrefix("uav66");
+  tf_opt = std::nullopt;
+  tf_opt = wait_for_tf("camera", "local_origin", tfr);
+  if (!tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "didn't get the transformation!");
+    result *= 0;
+  }
+
+  tf_opt = std::nullopt;
+  tf_opt = wait_for_tf("uav66/camera", "uav66/local_origin", tfr);
+  if (!tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "didn't get the transformation!");
+    result *= 0;
+  }
+
+  tfr.setDefaultPrefix("");
+  tf_opt = std::nullopt;
+  tf_opt = wait_for_tf("camera", "uav66/local_origin", tfr);
+  if (tf_opt.has_value())
+  {
+    ROS_ERROR_THROTTLE(1.0, "got the transform (that should not happen)");
     result *= 0;
   }
 
@@ -292,8 +549,19 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char** argv) {
   // Set up ROS.
   ros::init(argc, argv, "transformer_tests");
   ros::NodeHandle nh = ros::NodeHandle("~");
+  bc = std::make_unique<tf2_ros::TransformBroadcaster>();
+
+  local2local = anax_t(3.2, vec3_t::UnitZ());
+  local2local.translation() = 10*vec3_t::Random();
+  local2fcu = anax_t(1.2, vec3_t::UnitZ()) * anax_t(0.2, vec3_t::UnitX());
+  local2fcu.translation() = vec3_t::Random();
+  local2utm = Eigen::Affine3d::Identity();
+  fcu2cam = anax_t(1.54, vec3_t::UnitZ()) * anax_t(1.54, vec3_t::UnitX()) * anax_t(1.54, vec3_t::UnitY());
+  fcu2cam.translation() = vec3_t(0.2, 0, 0);
 
   ros::Time::waitForValid();
+
+  std::cout << "Initialized, running tests\n";
 
   testing::InitGoogleTest(&argc, argv);
 


### PR DESCRIPTION
The [`mrs_lib::Transformer` transformation helper class](https://ctu-mrs.github.io/mrs_lib/classmrs__lib_1_1Transformer.html) started as a specialized helper tool for the MRS UAV control pipeline to solve some issues specific to it. But the `Transformer` grew to be a larger thing that is now used in stuff that is not related to UAV control, so a lot of the specific functionality doesn't make sense in the more general cases.

This PR aims to address this problem by redefining the API, improving the documentation, and slightly rewriting the implementation without removing any functions of the original class.