### PR TITLE
Batch Visualizer - add automated timeout 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -259,7 +259,7 @@ target_link_libraries(rheiv_example
   ${Eigen_LIBRARIES}
   )
 
-add_library(MrsLibBatchVisualizer src/batch_visualizer/batch_visualizer.cpp)
+add_library(MrsLibBatchVisualizer src/batch_visualizer/batch_visualizer.cpp src/batch_visualizer/visual_object.cpp)
 target_link_libraries(MrsLibBatchVisualizer
   MrsLibGeometry
   ${catkin_LIBRARIES}

--- a/include/mrs_lib/batch_visualizer.h
+++ b/include/mrs_lib/batch_visualizer.h
@@ -11,6 +11,8 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <mrs_lib/geometry/shapes.h>
 #include <mrs_msgs/TrajectoryReference.h>
+#include <mrs_lib/batch_visualizer/visual_object.h>
+#include <set>
 
 #define DEFAULT_ELLIPSE_POINTS 64
 
@@ -48,8 +50,10 @@ public:
    * @param g green color in range <0,1>
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
-  void addPoint(const Eigen::Vector3d &point, const double r = 0.0, const double g = 1.0, const double b = 0.3, const double a = 1.0);
+  void addPoint(const Eigen::Vector3d &point, const double r = 0.0, const double g = 1.0, const double b = 0.3, const double a = 1.0,
+                const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a ray to the buffer
@@ -59,8 +63,10 @@ public:
    * @param g green color in range <0,1>
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
-  void addRay(const mrs_lib::geometry::Ray &ray, const double r = 1.0, const double g = 0.0, const double b = 0.0, const double a = 1.0);
+  void addRay(const mrs_lib::geometry::Ray &ray, const double r = 1.0, const double g = 0.0, const double b = 0.0, const double a = 1.0,
+              const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a triangle to the buffer
@@ -71,9 +77,10 @@ public:
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
    * @param filled bool to set fill. True = face visible, False = outline visible
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addTriangle(const mrs_lib::geometry::Triangle &tri, const double r = 0.5, const double g = 0.5, const double b = 0.0, const double a = 1.0,
-                   const bool filled = true);
+                   const bool filled = true, const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a rectangle to the buffer
@@ -84,9 +91,10 @@ public:
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
    * @param filled bool to set fill. True = face visible, False = outline visible
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addRectangle(const mrs_lib::geometry::Rectangle &rect, const double r = 0.5, const double g = 0.5, const double b = 0.0, const double a = 1.0,
-                    const bool filled = true);
+                    const bool filled = true, const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a cuboid to the buffer
@@ -97,9 +105,10 @@ public:
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
    * @param filled bool to set fill. True = face visible, False = outline visible
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addCuboid(const mrs_lib::geometry::Cuboid &cuboid, const double r = 0.5, const double g = 0.5, const double b = 0.0, const double a = 1.0,
-                 const bool filled = true);
+                 const bool filled = true, const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add an ellipse to the buffer
@@ -111,9 +120,10 @@ public:
    * @param a alpha in range <0,1> (0 is fully transparent)
    * @param filled bool to set fill. True = face visible, False = outline visible
    * @param num_points number of points to approximate the round shape
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addEllipse(const mrs_lib::geometry::Ellipse &ellipse, const double r = 0.0, const double g = 1.0, const double b = 1.0, const double a = 1.0,
-                  const bool filled = true, const int num_points = DEFAULT_ELLIPSE_POINTS);
+                  const bool filled = true, const int num_points = DEFAULT_ELLIPSE_POINTS, const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a cylinder to the buffer
@@ -126,9 +136,11 @@ public:
    * @param filled bool to set fill. True = face visible, False = outline visible
    * @param capped bool to set caps on/off. True = caps drawn, False = hollow cylinder
    * @param sides number of points to approximate the round shape
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addCylinder(const mrs_lib::geometry::Cylinder &cylinder, const double r = 0.7, const double g = 0.8, const double b = 0.3, const double a = 1.0,
-                   const bool filled = true, const bool capped = true, const int sides = DEFAULT_ELLIPSE_POINTS);
+                   const bool filled = true, const bool capped = true, const int sides = DEFAULT_ELLIPSE_POINTS,
+                   const ros::Duration &timeout = ros::Duration(0));
   /**
    * @brief add a cone to the buffer
    *
@@ -140,9 +152,10 @@ public:
    * @param filled bool to set fill. True = face visible, False = outline visible
    * @param capped bool to set caps on/off. True = cap drawn, False = base cap missing
    * @param sides number of points to approximate the round shape
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addCone(const mrs_lib::geometry::Cone &cone, const double r = 0.7, const double g = 0.8, const double b = 0.3, const double a = 1.0,
-               const bool filled = true, const bool capped = true, const int sides = DEFAULT_ELLIPSE_POINTS);
+               const bool filled = true, const bool capped = true, const int sides = DEFAULT_ELLIPSE_POINTS, const ros::Duration &timeout = ros::Duration(0));
 
   /**
    * @brief add a trajectory to the buffer
@@ -153,9 +166,14 @@ public:
    * @param b blue color in range <0,1>
    * @param a alpha in range <0,1> (0 is fully transparent)
    * @param filled bool to set fill. True = continuous line, False = only visualize points
+   * @param timeout time in seconds after which the object should be removed from buffer
    */
   void addTrajectory(const mrs_msgs::TrajectoryReference &traj, const double r = 0.3, const double g = 1.0, const double b = 0.3, const double a = 1.0,
-                     const bool filled = true);
+                     const bool filled = true, const ros::Duration &timeout = ros::Duration(0));
+
+  void addNullPoint();
+  void addNullLine();
+  void addNullTriangle();
 
   /**
    * @brief set the scale of all points
@@ -200,6 +218,8 @@ private:
   std::string parent_frame;
   std::string marker_topic_name;
 
+  std::set<VisualObject> visual_objects;
+
   visualization_msgs::Marker points_marker;
   visualization_msgs::Marker lines_marker;
   visualization_msgs::Marker triangles_marker;
@@ -210,11 +230,8 @@ private:
   double points_scale = 0.02;
   double lines_scale  = 0.04;
 
-  void addNullPoint();
-  void addNullLine();
-  void addNullTriangle();
+  unsigned long uuid = 0;
 
-  std::vector<Eigen::Vector3d> buildEllipse(const mrs_lib::geometry::Ellipse &ellispe, const int num_points = DEFAULT_ELLIPSE_POINTS);
 };
 
 }  // namespace mrs_lib

--- a/include/mrs_lib/batch_visualizer.h
+++ b/include/mrs_lib/batch_visualizer.h
@@ -11,7 +11,7 @@
 #include <visualization_msgs/MarkerArray.h>
 #include <mrs_lib/geometry/shapes.h>
 #include <mrs_msgs/TrajectoryReference.h>
-#include <mrs_lib/batch_visualizer/visual_object.h>
+#include <mrs_lib/visual_object.h>
 #include <set>
 
 #define DEFAULT_ELLIPSE_POINTS 64
@@ -171,8 +171,19 @@ public:
   void addTrajectory(const mrs_msgs::TrajectoryReference &traj, const double r = 0.3, const double g = 1.0, const double b = 0.3, const double a = 1.0,
                      const bool filled = true, const ros::Duration &timeout = ros::Duration(0));
 
+  /**
+   * @brief helper function for adding an invisible point to the object buffer
+   */
   void addNullPoint();
+
+  /**
+   * @brief helper function for adding an invisible line to the object buffer
+   */
   void addNullLine();
+
+  /**
+   * @brief helper function for adding an invisible triangle to the buffer
+   */
   void addNullTriangle();
 
   /**
@@ -215,10 +226,10 @@ private:
   ros::Publisher                  visual_pub;
   visualization_msgs::MarkerArray msg;
 
-  std::string parent_frame;
+  std::string parent_frame; // coordinate frame id
   std::string marker_topic_name;
 
-  std::set<VisualObject> visual_objects;
+  std::set<VisualObject> visual_objects; // buffer for objects to be visualized
 
   visualization_msgs::Marker points_marker;
   visualization_msgs::Marker lines_marker;
@@ -230,8 +241,7 @@ private:
   double points_scale = 0.02;
   double lines_scale  = 0.04;
 
-  unsigned long uuid = 0;
-
+  unsigned long uuid = 0; // create unique ID for items in object buffer
 };
 
 }  // namespace mrs_lib

--- a/include/mrs_lib/batch_visualizer/visual_object.h
+++ b/include/mrs_lib/batch_visualizer/visual_object.h
@@ -1,0 +1,99 @@
+/**  \file
+     \brief Object abstraction for the Batch Visualizer
+     \author Petr Štibinger - stibipet@fel.cvut.cz
+ */
+
+#ifndef BATCH_VISUALIZER__VISUAL_OBJECT_H
+#define BATCH_VISUALIZER__VISUAL_OBJECT_H
+
+#include <Eigen/Core>
+#include <ros/time.h>
+#include <std_msgs/ColorRGBA.h>
+#include <geometry_msgs/Point.h>
+#include <mrs_lib/geometry/shapes.h>
+#include <mrs_msgs/TrajectoryReference.h>
+
+#define DEFAULT_ELLIPSE_POINTS 64
+
+namespace mrs_lib
+{
+
+enum MarkerType
+{
+  POINT    = 0,
+  LINE     = 1,
+  TRIANGLE = 2
+};
+
+class VisualObject {
+
+
+public:
+  VisualObject(const Eigen::Vector3d& point, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const unsigned long& id);
+
+  VisualObject(const mrs_lib::geometry::Ray& ray, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const unsigned long& id);
+
+  VisualObject(const mrs_lib::geometry::Triangle& triangle, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const unsigned long& id);
+
+  VisualObject(const mrs_lib::geometry::Rectangle& rectangle, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const unsigned long& id);
+
+  VisualObject(const mrs_lib::geometry::Cuboid& cuboid, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const unsigned long& id);
+
+  VisualObject(const mrs_lib::geometry::Ellipse& ellipse, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const unsigned long& id, const int num_points = DEFAULT_ELLIPSE_POINTS);
+
+  VisualObject(const mrs_lib::geometry::Cylinder& cylinder, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const bool capped, const unsigned long& id, const int num_sides = DEFAULT_ELLIPSE_POINTS);
+
+  VisualObject(const mrs_lib::geometry::Cone& cone, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const bool capped, const unsigned long& id, const int num_sides = DEFAULT_ELLIPSE_POINTS);
+
+  VisualObject(const mrs_msgs::TrajectoryReference& traj, const double r, const double g, const double b, const double a, const ros::Duration& timeout, const bool filled,
+               const unsigned long& id);
+
+
+public:
+  unsigned long getID() const;
+  int           getType() const;
+  bool          isTimedOut() const;
+
+  const std::vector<geometry_msgs::Point> getPoints() const;
+  const std::vector<std_msgs::ColorRGBA>  getColors() const;
+
+  bool operator<(const VisualObject& other) const {
+    return id_ < other.id_;
+  }
+
+  bool operator>(const VisualObject& other) const {
+    return id_ > other.id_;
+  }
+
+  bool operator==(const VisualObject& other) const {
+    return id_ == other.id_;
+  }
+
+private:
+  const unsigned long               id_;
+  MarkerType                        type_;
+  std::vector<geometry_msgs::Point> points_;
+  std::vector<std_msgs::ColorRGBA>  colors_;
+  ros::Time                         timeout_time_;
+
+  void addRay(const mrs_lib::geometry::Ray& ray, const double r, const double g, const double b, const double a);
+
+  void addTriangle(const mrs_lib::geometry::Triangle& triangle, const double r, const double g, const double b, const double a, const bool filled);
+
+  void addEllipse(const mrs_lib::geometry::Ellipse& ellipse, const double r, const double g, const double b, const double a, const bool filled,
+                  const int num_points);
+
+
+};  // namespace batch_visualizer
+
+}  // namespace mrs_lib
+
+#endif

--- a/include/mrs_lib/visual_object.h
+++ b/include/mrs_lib/visual_object.h
@@ -53,8 +53,8 @@ public:
   VisualObject(const mrs_lib::geometry::Cone& cone, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
                const bool filled, const bool capped, const unsigned long& id, const int num_sides = DEFAULT_ELLIPSE_POINTS);
 
-  VisualObject(const mrs_msgs::TrajectoryReference& traj, const double r, const double g, const double b, const double a, const ros::Duration& timeout, const bool filled,
-               const unsigned long& id);
+  VisualObject(const mrs_msgs::TrajectoryReference& traj, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+               const bool filled, const unsigned long& id);
 
 
 public:
@@ -90,7 +90,6 @@ private:
 
   void addEllipse(const mrs_lib::geometry::Ellipse& ellipse, const double r, const double g, const double b, const double a, const bool filled,
                   const int num_points);
-
 
 };  // namespace batch_visualizer
 

--- a/src/batch_visualizer/batch_visualizer_demo.cpp
+++ b/src/batch_visualizer/batch_visualizer_demo.cpp
@@ -16,297 +16,308 @@ std::uniform_real_distribution<double> rand_percent(0, 1);
 
 int main(int argc, char** argv) {
 
-  ros::init(argc, argv, "radiation_utils_test");
+  ros::init(argc, argv, "batch_visualizer_demo");
   ros::NodeHandle nh = ros::NodeHandle("~");
 
   ROS_INFO("[%s]: Test started!", ros::this_node::getName().c_str());
 
   BatchVisualizer bv;
   bv = BatchVisualizer(nh, "test_markers", "map");
-
-  bv.clearBuffers();
-  bv.clearVisuals();
   bv.setPointsScale(0.4);
+  bv.clearVisuals();
 
-    /* RANDOM POINTS //{ */
-    ROS_INFO("[%s]: Generating random points..", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 400 && ros::ok()); i++) {
-      double          x = rand_dbl(generator);
-      double          y = rand_dbl(generator);
-      double          z = rand_dbl(generator);
-      Eigen::Vector3d point(x, y, z);
-      double          r = (x - range_min) / (range_max - range_min);
-      double          g = (y - range_min) / (range_max - range_min);
-      double          b = (z - range_min) / (range_max - range_min);
-      bv.addPoint(point, r, g, b, 1);
-      ros::spinOnce();
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.005).sleep();
+  /* RANDOM POINTS //{ */
+  ROS_INFO("[%s]: Generating random points..", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 400 && ros::ok()); i++) {
+    double          x = rand_dbl(generator);
+    double          y = rand_dbl(generator);
+    double          z = rand_dbl(generator);
+    Eigen::Vector3d point(x, y, z);
+    double          r = (x - range_min) / (range_max - range_min);
+    double          g = (y - range_min) / (range_max - range_min);
+    double          b = (z - range_min) / (range_max - range_min);
+    bv.addPoint(point, r, g, b, 1, ros::Duration(0.2));
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.005).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RANDOM RAYS //{ */
+  ROS_INFO("[%s]: Generating random rays...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          x1 = rand_dbl(generator);
+    double          y1 = rand_dbl(generator);
+    double          z1 = rand_dbl(generator);
+    Eigen::Vector3d point1(x1, y1, z1);
+    double          x2 = rand_dbl(generator);
+    double          y2 = rand_dbl(generator);
+    double          z2 = rand_dbl(generator);
+    Eigen::Vector3d point2(x2, y2, z2);
+    Ray             ray = Ray::twopointCast(point1, point2);
+    double          r   = ((x1 * x2) - range_min) / (range_max - range_min);
+    double          g   = ((y1 * y2) - range_min) / (range_max - range_min);
+    double          b   = ((z1 * z2) - range_min) / (range_max - range_min);
+    bv.addRay(ray, r, g, b, 1, ros::Duration(0.7));
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RAYS FROM ORIGIN //{ */
+  ROS_INFO("[%s]: Generating rays originating from one point..", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          a = rand_dbl(generator);
+    double          b = rand_dbl(generator);
+    double          c = rand_dbl(generator);
+    Eigen::Vector3d point(a, b, c);
+    Ray             ray = Ray::twopointCast(Eigen::Vector3d::Zero(), point);
+    double          r   = (i + 1) / 100.0;
+    double          g   = 1 - r;
+    bv.addRay(ray, r, g, 0, 1, ros::Duration(0.7));
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RANDOM FILLED TRIANGLES //{ */
+  ROS_INFO("[%s]: Generating random filled triangles...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          x1 = rand_dbl(generator);
+    double          y1 = rand_dbl(generator);
+    double          z1 = rand_dbl(generator);
+    Eigen::Vector3d point1(x1, y1, z1);
+    double          x2 = rand_dbl(generator);
+    double          y2 = rand_dbl(generator);
+    double          z2 = rand_dbl(generator);
+    Eigen::Vector3d point2(x2, y2, z2);
+    double          x3 = rand_dbl(generator);
+    double          y3 = rand_dbl(generator);
+    double          z3 = rand_dbl(generator);
+    Eigen::Vector3d point3(x3, y3, z3);
+    double          r = x1 * x2 * x3;
+    double          g = y1 * y2 * y3;
+    double          b = z1 * z2 * z3;
+    Triangle        tri(point1, point2, point3);
+    bv.addTriangle(tri, r, g, b, 1, true);
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RANDOM OUTLINED TRIANGLES //{ */
+  ROS_INFO("[%s]: Generating random outlined triangles...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          x1 = rand_dbl(generator);
+    double          y1 = rand_dbl(generator);
+    double          z1 = rand_dbl(generator);
+    Eigen::Vector3d point1(x1, y1, z1);
+    double          x2 = rand_dbl(generator);
+    double          y2 = rand_dbl(generator);
+    double          z2 = rand_dbl(generator);
+    Eigen::Vector3d point2(x2, y2, z2);
+    double          x3 = rand_dbl(generator);
+    double          y3 = rand_dbl(generator);
+    double          z3 = rand_dbl(generator);
+    Eigen::Vector3d point3(x3, y3, z3);
+    double          r = x1 * x2 * x3;
+    double          g = y1 * y2 * y3;
+    double          b = z1 * z2 * z3;
+    Triangle        tri(point1, point2, point3);
+    bv.addTriangle(tri, r, g, b, 1, false);
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RANDOM RECTANGLES //{ */
+  ROS_INFO("[%s]: Generating random rectangles...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          x1 = rand_dbl(generator);
+    double          y1 = rand_dbl(generator);
+    double          z1 = rand_dbl(generator);
+    Eigen::Vector3d point1(x1, y1, z1);
+    double          x2 = rand_dbl(generator);
+    double          y2 = rand_dbl(generator);
+    double          z2 = rand_dbl(generator);
+    Eigen::Vector3d point2(x2, y2, z2);
+    double          plane_x = rand_dbl(generator);
+    double          plane_y = rand_dbl(generator);
+    double          plane_z = rand_dbl(generator);
+    Eigen::Vector3d plane_anchor(plane_x, plane_y, plane_z);
+    double          side_length2 = rand_dbl(generator) / 2.0;
+    Eigen::Vector3d point3       = point2 + side_length2 * (((point2 - point1).cross(plane_anchor - point1)).normalized());
+    Eigen::Vector3d point4       = point1 + side_length2 * (((point2 - point1).cross(plane_anchor - point1)).normalized());
+
+    double    r = x1 * x2;
+    double    g = y1 * y2;
+    double    b = z1 * z2;
+    Rectangle rect(point1, point2, point3, point4);
+    bv.addRectangle(rect, r, g, b, 1, true);   // draw colored faces
+    bv.addRectangle(rect, 0, 0, 0, 1, false);  // draw outlines
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  bv.clearBuffers();
+  //}
+
+  /* RANDOM CUBES //{ */
+  ROS_INFO("[%s]: Generating random cubes...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double             x1 = rand_dbl(generator);
+    double             y1 = rand_dbl(generator);
+    double             z1 = rand_dbl(generator);
+    Eigen::Vector3d    center(x1, y1, z1);
+    double             s = 0.4 * rand_dbl(generator);
+    Eigen::Vector3d    scale(s, s, s);
+    double             x2          = rand_dbl(generator);
+    double             y2          = rand_dbl(generator);
+    double             z2          = rand_dbl(generator);
+    Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
+
+    double r = (x1 - range_min) / (range_max - range_min);
+    double g = (y1 - range_min) / (range_max - range_min);
+    double b = (z1 - range_min) / (range_max - range_min);
+    Cuboid cub(center, scale, orientation);
+
+    bv.addCuboid(cub, r, g, b, 1, true);   // draw colored faces
+    bv.addCuboid(cub, 0, 0, 0, 1, false);  // draw outlines
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
+
+  /* RANDOM ELLIPSES //{ */
+  ROS_INFO("[%s]: Generating random ellipses...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double             x1 = rand_dbl(generator);
+    double             y1 = rand_dbl(generator);
+    double             z1 = rand_dbl(generator);
+    Eigen::Vector3d    center(x1, y1, z1);
+    double             major       = 0.4 * rand_dbl(generator);
+    double             minor       = 0.1 * rand_dbl(generator);
+    double             x2          = rand_dbl(generator);
+    double             y2          = rand_dbl(generator);
+    double             z2          = rand_dbl(generator);
+    Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
+
+    double  r = (x1 - range_min) / (range_max - range_min);
+    double  g = (y1 - range_min) / (range_max - range_min);
+    double  b = (z1 - range_min) / (range_max - range_min);
+    Ellipse el(center, orientation, major, minor);
+
+    bv.addEllipse(el, r, g, b, 1.0, true);         // colored face
+    bv.addEllipse(el, 0.0, 0.0, 0.0, 1.0, false);  // black outline
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
+
+  /* RANDOM CYLINDERS//{ */
+  ROS_INFO("[%s]: Generating random cylinders...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double             x1 = rand_dbl(generator);
+    double             y1 = rand_dbl(generator);
+    double             z1 = rand_dbl(generator);
+    Eigen::Vector3d    center(x1, y1, z1);
+    double             x2          = rand_dbl(generator);
+    double             y2          = rand_dbl(generator);
+    double             z2          = rand_dbl(generator);
+    Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
+
+    double radius = 0.3 * rand_dbl(generator);
+    double height = rand_dbl(generator);
+
+    double r = (x1 - range_min) / (range_max - range_min);
+    double g = (y1 - range_min) / (range_max - range_min);
+    double b = (z1 - range_min) / (range_max - range_min);
+
+    Cylinder cyl(center, radius, height, orientation);
+    bv.addCylinder(cyl, r, g, b, 1.0, true, true, 12);
+    bv.addCylinder(cyl, 0, 0, 0, 1, false, false, 12);
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
+
+  /* RANDOM CONES //{ */
+  ROS_INFO("[%s]: Generating random cones...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    double          x1 = rand_dbl(generator);
+    double          y1 = rand_dbl(generator);
+    double          z1 = rand_dbl(generator);
+    Eigen::Vector3d origin(x1, y1, z1);
+    double          x2 = rand_dbl(generator);
+    double          y2 = rand_dbl(generator);
+    double          z2 = rand_dbl(generator);
+    Eigen::Vector3d direction(x2, y2, z2);
+
+    double angle  = 0.02 * rand_dbl(generator);
+    double height = rand_dbl(generator);
+
+    double r = (x1 - range_min) / (range_max - range_min);
+    double g = (y1 - range_min) / (range_max - range_min);
+    double b = (z1 - range_min) / (range_max - range_min);
+
+    Cone cone(origin, angle, height, direction);
+    bv.addCone(cone, r, g, b, 1.0, true, true, 12);
+    bv.addCone(cone, 0, 0, 0, 1, false, false, 12);
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
+
+  /* RANDOM TRAJECTORIES //{ */
+  ROS_INFO("[%s]: Generating random trajectories...", ros::this_node::getName().c_str());
+  for (int i = 0; (i < 200 && ros::ok()); i++) {
+    mrs_msgs::TrajectoryReference traj;
+    for (int n = 0; n < 20; n++) {
+      double              x = rand_dbl(generator);
+      double              y = rand_dbl(generator);
+      double              z = rand_dbl(generator);
+      mrs_msgs::Reference ref;
+      ref.position.x = x;
+      ref.position.y = y;
+      ref.position.z = z;
+      traj.points.push_back(ref);
     }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
 
-    /* RANDOM RAYS //{ */
-    ROS_INFO("[%s]: Generating random rays...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          x1 = rand_dbl(generator);
-      double          y1 = rand_dbl(generator);
-      double          z1 = rand_dbl(generator);
-      Eigen::Vector3d point1(x1, y1, z1);
-      double          x2 = rand_dbl(generator);
-      double          y2 = rand_dbl(generator);
-      double          z2 = rand_dbl(generator);
-      Eigen::Vector3d point2(x2, y2, z2);
-      Ray             ray = Ray::twopointCast(point1, point2);
-      double          r   = ((x1 * x2) - range_min) / (range_max - range_min);
-      double          g   = ((y1 * y2) - range_min) / (range_max - range_min);
-      double          b   = ((z1 * z2) - range_min) / (range_max - range_min);
-      bv.addRay(ray, r, g, b, 1);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
-
-    /* RAYS FROM ORIGIN //{ */
-    ROS_INFO("[%s]: Generating rays originating from one point..", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          a = rand_dbl(generator);
-      double          b = rand_dbl(generator);
-      double          c = rand_dbl(generator);
-      Eigen::Vector3d point(a, b, c);
-      Ray             ray = Ray::twopointCast(Eigen::Vector3d::Zero(), point);
-      double          r   = (i + 1) / 100.0;
-      double          g   = 1 - r;
-      bv.addRay(ray, r, g, 0, 1);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
-
-    /* RANDOM FILLED TRIANGLES //{ */
-    ROS_INFO("[%s]: Generating random filled triangles...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          x1 = rand_dbl(generator);
-      double          y1 = rand_dbl(generator);
-      double          z1 = rand_dbl(generator);
-      Eigen::Vector3d point1(x1, y1, z1);
-      double          x2 = rand_dbl(generator);
-      double          y2 = rand_dbl(generator);
-      double          z2 = rand_dbl(generator);
-      Eigen::Vector3d point2(x2, y2, z2);
-      double          x3 = rand_dbl(generator);
-      double          y3 = rand_dbl(generator);
-      double          z3 = rand_dbl(generator);
-      Eigen::Vector3d point3(x3, y3, z3);
-      double          r = x1 * x2 * x3;
-      double          g = y1 * y2 * y3;
-      double          b = z1 * z2 * z3;
-      Triangle        tri(point1, point2, point3);
-      bv.addTriangle(tri, r, g, b, 1, true);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
-
-    /* RANDOM OUTLINED TRIANGLES //{ */
-    ROS_INFO("[%s]: Generating random outlined triangles...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          x1 = rand_dbl(generator);
-      double          y1 = rand_dbl(generator);
-      double          z1 = rand_dbl(generator);
-      Eigen::Vector3d point1(x1, y1, z1);
-      double          x2 = rand_dbl(generator);
-      double          y2 = rand_dbl(generator);
-      double          z2 = rand_dbl(generator);
-      Eigen::Vector3d point2(x2, y2, z2);
-      double          x3 = rand_dbl(generator);
-      double          y3 = rand_dbl(generator);
-      double          z3 = rand_dbl(generator);
-      Eigen::Vector3d point3(x3, y3, z3);
-      double          r = x1 * x2 * x3;
-      double          g = y1 * y2 * y3;
-      double          b = z1 * z2 * z3;
-      Triangle        tri(point1, point2, point3);
-      bv.addTriangle(tri, r, g, b, 1, false);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
-
-    /* RANDOM RECTANGLES //{ */
-    ROS_INFO("[%s]: Generating random rectangles...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          x1 = rand_dbl(generator);
-      double          y1 = rand_dbl(generator);
-      double          z1 = rand_dbl(generator);
-      Eigen::Vector3d point1(x1, y1, z1);
-      double          x2 = rand_dbl(generator);
-      double          y2 = rand_dbl(generator);
-      double          z2 = rand_dbl(generator);
-      Eigen::Vector3d point2(x2, y2, z2);
-      double          plane_x = rand_dbl(generator);
-      double          plane_y = rand_dbl(generator);
-      double          plane_z = rand_dbl(generator);
-      Eigen::Vector3d plane_anchor(plane_x, plane_y, plane_z);
-      double          side_length2 = rand_dbl(generator) / 2.0;
-      Eigen::Vector3d point3       = point2 + side_length2 * (((point2 - point1).cross(plane_anchor - point1)).normalized());
-      Eigen::Vector3d point4       = point1 + side_length2 * (((point2 - point1).cross(plane_anchor - point1)).normalized());
-
-      double    r = x1 * x2;
-      double    g = y1 * y2;
-      double    b = z1 * z2;
-      Rectangle rect(point1, point2, point3, point4);
-      bv.addRectangle(rect, r, g, b, 1, true);   // draw colored faces
-      bv.addRectangle(rect, 0, 0, 0, 1, false);  // draw outlines
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    bv.clearBuffers();
-    bv.clearVisuals();
-    //}
-
-    /* RANDOM CUBES //{ */
-    ROS_INFO("[%s]: Generating random cubes...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double             x1 = rand_dbl(generator);
-      double             y1 = rand_dbl(generator);
-      double             z1 = rand_dbl(generator);
-      Eigen::Vector3d    center(x1, y1, z1);
-      double             s = 0.4 * rand_dbl(generator);
-      Eigen::Vector3d    scale(s, s, s);
-      double             x2          = rand_dbl(generator);
-      double             y2          = rand_dbl(generator);
-      double             z2          = rand_dbl(generator);
-      Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
-
-      double r = (x1 - range_min) / (range_max - range_min);
-      double g = (y1 - range_min) / (range_max - range_min);
-      double b = (z1 - range_min) / (range_max - range_min);
-      Cuboid cub(center, scale, orientation);
-
-      bv.addCuboid(cub, r, g, b, 1, true);   // draw colored faces
-      bv.addCuboid(cub, 0, 0, 0, 1, false);  // draw outlines
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    bv.clearBuffers();
-    bv.clearVisuals();
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    //}
-
-    /* RANDOM ELLIPSES //{ */
-    ROS_INFO("[%s]: Generating random ellipses...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double             x1 = rand_dbl(generator);
-      double             y1 = rand_dbl(generator);
-      double             z1 = rand_dbl(generator);
-      Eigen::Vector3d    center(x1, y1, z1);
-      double             major       = 0.4 * rand_dbl(generator);
-      double             minor       = 0.1 * rand_dbl(generator);
-      double             x2          = rand_dbl(generator);
-      double             y2          = rand_dbl(generator);
-      double             z2          = rand_dbl(generator);
-      Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
-
-      double  r = (x1 - range_min) / (range_max - range_min);
-      double  g = (y1 - range_min) / (range_max - range_min);
-      double  b = (z1 - range_min) / (range_max - range_min);
-      Ellipse el(center, orientation, major, minor);
-
-      bv.addEllipse(el, r, g, b, 1.0, true);         // colored face
-      bv.addEllipse(el, 0.0, 0.0, 0.0, 1.0, false);  // black outline
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    bv.clearBuffers();
-    bv.clearVisuals();
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    //}
-
-    /* RANDOM CYLINDERS//{ */
-    ROS_INFO("[%s]: Generating random cylinders...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double             x1 = rand_dbl(generator);
-      double             y1 = rand_dbl(generator);
-      double             z1 = rand_dbl(generator);
-      Eigen::Vector3d    center(x1, y1, z1);
-      double             x2          = rand_dbl(generator);
-      double             y2          = rand_dbl(generator);
-      double             z2          = rand_dbl(generator);
-      Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
-
-      double radius = 0.3 * rand_dbl(generator);
-      double height = rand_dbl(generator);
-
-      double r = (x1 - range_min) / (range_max - range_min);
-      double g = (y1 - range_min) / (range_max - range_min);
-      double b = (z1 - range_min) / (range_max - range_min);
-
-      Cylinder cyl(center, radius, height, orientation);
-      bv.addCylinder(cyl, r, g, b, 1.0, true, true, 12);
-      bv.addCylinder(cyl, 0, 0, 0, 1, false, false, 12);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    bv.clearBuffers();
-    bv.clearVisuals();
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    //}
-
-    /* RANDOM CONES //{ */
-    ROS_INFO("[%s]: Generating random cones...", ros::this_node::getName().c_str());
-    for (int i = 0; (i < 200 && ros::ok()); i++) {
-      double          x1 = rand_dbl(generator);
-      double          y1 = rand_dbl(generator);
-      double          z1 = rand_dbl(generator);
-      Eigen::Vector3d origin(x1, y1, z1);
-      double          x2 = rand_dbl(generator);
-      double          y2 = rand_dbl(generator);
-      double          z2 = rand_dbl(generator);
-      Eigen::Vector3d direction(x2, y2, z2);
-
-      double angle  = 0.02 * rand_dbl(generator);
-      double height = rand_dbl(generator);
-
-      double r = (x1 - range_min) / (range_max - range_min);
-      double g = (y1 - range_min) / (range_max - range_min);
-      double b = (z1 - range_min) / (range_max - range_min);
-
-      Cone cone(origin, angle, height, direction);
-      bv.addCone(cone, r, g, b, 1.0, true, true, 12);
-      bv.addCone(cone, 0, 0, 0, 1, false, false, 12);
-      bv.publish();
-      ros::spinOnce();
-      ros::Duration(0.01).sleep();
-    }
-    /* bv.clearBuffers(); */
-    /* bv.clearVisuals(); */
-    ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
-    //}
+    bv.addTrajectory(traj, 0, 1, 1, 1.0, true, ros::Duration(0.05));
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.01).sleep();
+  }
+  bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
 
   /* RAYTRACING TEST //{ */
   ROS_INFO("[%s]: Generating random rays and triangles...", ros::this_node::getName().c_str());
@@ -334,22 +345,19 @@ int main(int argc, char** argv) {
     double          rz2 = rand_dbl(generator);
     Eigen::Vector3d ray_point2(rx2, ry2, rz2);
     Ray             ray = Ray::twopointCast(ray_point1, ray_point2);
-    bv.addRay(ray, 1.0, 0.5, 0.0, 1.0);
+    bv.addRay(ray, 1.0, 0.5, 0.0, 1.0, ros::Duration(0.3));
 
     if (tri.intersectionRay(ray) == boost::none) {
-      bv.addTriangle(tri, 1.0, 0.0, 0.0, 1.0, true);
+      bv.addTriangle(tri, 1.0, 0.0, 0.0, 1.0, true, ros::Duration(0.3));
     } else {
-      bv.addTriangle(tri, 0.0, 1.0, 0.3, 1.0, true);
-      bv.addPoint(tri.intersectionRay(ray).get());
+      bv.addTriangle(tri, 0.0, 1.0, 0.3, 1.0, true, ros::Duration(0.3));
+      bv.addPoint(tri.intersectionRay(ray).get(), 1, 1, 0, 1, ros::Duration(0.3));
     }
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.6).sleep();
-    bv.clearBuffers();
-    bv.clearVisuals();
   }
-  /* bv.clearBuffers(); */
-  /* bv.clearVisuals(); */
+  bv.clearBuffers();
   ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
   //}
 

--- a/src/batch_visualizer/batch_visualizer_demo.cpp
+++ b/src/batch_visualizer/batch_visualizer_demo.cpp
@@ -107,7 +107,7 @@ int main(int argc, char** argv) {
     double          g = y1 * y2 * y3;
     double          b = z1 * z2 * z3;
     Triangle        tri(point1, point2, point3);
-    bv.addTriangle(tri, r, g, b, 1, true);
+    bv.addTriangle(tri, r, g, b, 1, true, ros::Duration(0.5));
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -135,7 +135,7 @@ int main(int argc, char** argv) {
     double          g = y1 * y2 * y3;
     double          b = z1 * z2 * z3;
     Triangle        tri(point1, point2, point3);
-    bv.addTriangle(tri, r, g, b, 1, false);
+    bv.addTriangle(tri, r, g, b, 1, false, ros::Duration(0.5));
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -167,8 +167,8 @@ int main(int argc, char** argv) {
     double    g = y1 * y2;
     double    b = z1 * z2;
     Rectangle rect(point1, point2, point3, point4);
-    bv.addRectangle(rect, r, g, b, 1, true);   // draw colored faces
-    bv.addRectangle(rect, 0, 0, 0, 1, false);  // draw outlines
+    bv.addRectangle(rect, r, g, b, 1, true, ros::Duration(0.5));   // draw colored faces
+    bv.addRectangle(rect, 0, 0, 0, 1, false, ros::Duration(0.7));  // draw outlines
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -196,8 +196,8 @@ int main(int argc, char** argv) {
     double b = (z1 - range_min) / (range_max - range_min);
     Cuboid cub(center, scale, orientation);
 
-    bv.addCuboid(cub, r, g, b, 1, true);   // draw colored faces
-    bv.addCuboid(cub, 0, 0, 0, 1, false);  // draw outlines
+    bv.addCuboid(cub, r, g, b, 1, true, ros::Duration(0.3));   // draw colored faces
+    bv.addCuboid(cub, 0, 0, 0, 1, false, ros::Duration(0.3));  // draw outlines
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -225,8 +225,8 @@ int main(int argc, char** argv) {
     double  b = (z1 - range_min) / (range_max - range_min);
     Ellipse el(center, orientation, major, minor);
 
-    bv.addEllipse(el, r, g, b, 1.0, true);         // colored face
-    bv.addEllipse(el, 0.0, 0.0, 0.0, 1.0, false);  // black outline
+    bv.addEllipse(el, r, g, b, 1.0, true, 64, ros::Duration(0.5));         // colored face
+    bv.addEllipse(el, 0.0, 0.0, 0.0, 1.0, false, 64, ros::Duration(0.5));  // black outline
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -255,8 +255,8 @@ int main(int argc, char** argv) {
     double b = (z1 - range_min) / (range_max - range_min);
 
     Cylinder cyl(center, radius, height, orientation);
-    bv.addCylinder(cyl, r, g, b, 1.0, true, true, 12);
-    bv.addCylinder(cyl, 0, 0, 0, 1, false, false, 12);
+    bv.addCylinder(cyl, r, g, b, 1.0, true, true, 12, ros::Duration(0.5));
+    bv.addCylinder(cyl, 0, 0, 0, 1, false, false, 12, ros::Duration(0.5));
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -285,8 +285,8 @@ int main(int argc, char** argv) {
     double b = (z1 - range_min) / (range_max - range_min);
 
     Cone cone(origin, angle, height, direction);
-    bv.addCone(cone, r, g, b, 1.0, true, true, 12);
-    bv.addCone(cone, 0, 0, 0, 1, false, false, 12);
+    bv.addCone(cone, r, g, b, 1.0, true, true, 12, ros::Duration(0.5));
+    bv.addCone(cone, 0, 0, 0, 1, false, false, 12, ros::Duration(0.5));
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -299,7 +299,7 @@ int main(int argc, char** argv) {
   ROS_INFO("[%s]: Generating random trajectories...", ros::this_node::getName().c_str());
   for (int i = 0; (i < 200 && ros::ok()); i++) {
     mrs_msgs::TrajectoryReference traj;
-    for (int n = 0; n < 20; n++) {
+    for (int n = 0; n < 10; n++) {
       double              x = rand_dbl(generator);
       double              y = rand_dbl(generator);
       double              z = rand_dbl(generator);
@@ -310,7 +310,7 @@ int main(int argc, char** argv) {
       traj.points.push_back(ref);
     }
 
-    bv.addTrajectory(traj, 0, 1, 1, 1.0, true, ros::Duration(0.05));
+    bv.addTrajectory(traj, 0, 1, 1, 1.0, true, ros::Duration(0.08));
     bv.publish();
     ros::spinOnce();
     ros::Duration(0.01).sleep();
@@ -320,6 +320,8 @@ int main(int argc, char** argv) {
   //}
 
   /* RAYTRACING TEST //{ */
+  bv.setLinesScale(0.3);
+  bv.setPointsScale(1.0);
   ROS_INFO("[%s]: Generating random rays and triangles...", ros::this_node::getName().c_str());
   for (int i = 0; (i < 20 && ros::ok()); i++) {
     double          x1 = rand_dbl(generator);
@@ -333,17 +335,17 @@ int main(int argc, char** argv) {
     double          x3 = rand_dbl(generator);
     double          y3 = rand_dbl(generator);
     double          z3 = rand_dbl(generator);
-    Eigen::Vector3d point3(x3, y3, z3);
+    Eigen::Vector3d point3(3 * x3, 3 * y3, 3 * z3);
     Triangle        tri(point1, point2, point3);
 
     double          rx1 = rand_dbl(generator);
     double          ry1 = rand_dbl(generator);
     double          rz1 = rand_dbl(generator);
-    Eigen::Vector3d ray_point1(rx1, ry1, rz1);
+    Eigen::Vector3d ray_point1(4 * rx1, 4 * ry1, 4 * rz1);
     double          rx2 = rand_dbl(generator);
     double          ry2 = rand_dbl(generator);
     double          rz2 = rand_dbl(generator);
-    Eigen::Vector3d ray_point2(rx2, ry2, rz2);
+    Eigen::Vector3d ray_point2(4 * rx2, 4 * ry2, 4 * rz2);
     Ray             ray = Ray::twopointCast(ray_point1, ray_point2);
     bv.addRay(ray, 1.0, 0.5, 0.0, 1.0, ros::Duration(0.3));
 
@@ -358,6 +360,72 @@ int main(int argc, char** argv) {
     ros::Duration(0.6).sleep();
   }
   bv.clearBuffers();
+  ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
+  //}
+
+  /* RANDOM CHAOS //{ */
+  bv.setLinesScale(0.08);
+  bv.setPointsScale(0.6);
+  ROS_INFO("[%s]: Generating random chaos...", ros::this_node::getName().c_str());
+  for (int n = 0; n < 100; n++) {
+    for (int i = 0; (i < 300 && ros::ok()); i++) {
+      double          x = rand_dbl(generator);
+      double          y = rand_dbl(generator);
+      double          z = rand_dbl(generator);
+      Eigen::Vector3d point(x, y, z);
+      double          r           = (x - range_min) / (range_max - range_min);
+      double          g           = (y - range_min) / (range_max - range_min);
+      double          b           = (z - range_min) / (range_max - range_min);
+      double          timeout_sec = 0.2 * rand_percent(generator);
+      bv.addPoint(point, r, g, b, 1, ros::Duration(timeout_sec));
+    }
+    for (int i = 0; (i < 100 && ros::ok()); i++) {
+      double             x1 = rand_dbl(generator);
+      double             y1 = rand_dbl(generator);
+      double             z1 = rand_dbl(generator);
+      Eigen::Vector3d    center(x1, y1, z1);
+      double             s = 0.4 * rand_dbl(generator);
+      Eigen::Vector3d    scale(s, s, s);
+      double             x2          = rand_dbl(generator);
+      double             y2          = rand_dbl(generator);
+      double             z2          = rand_dbl(generator);
+      Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
+
+      double r = (x1 - range_min) / (range_max - range_min);
+      double g = (y1 - range_min) / (range_max - range_min);
+      double b = (z1 - range_min) / (range_max - range_min);
+      Cuboid cub(center, scale, orientation);
+      double timeout_sec = 0.2 * rand_percent(generator);
+
+      bv.addCuboid(cub, r, g, b, 1, true, ros::Duration(timeout_sec));   // draw colored faces
+      bv.addCuboid(cub, 0, 0, 0, 1, false, ros::Duration(timeout_sec));  // draw outlines
+    }
+    for (int i = 0; (i < 100 && ros::ok()); i++) {
+      double             x1 = rand_dbl(generator);
+      double             y1 = rand_dbl(generator);
+      double             z1 = rand_dbl(generator);
+      Eigen::Vector3d    center(x1, y1, z1);
+      double             x2          = rand_dbl(generator);
+      double             y2          = rand_dbl(generator);
+      double             z2          = rand_dbl(generator);
+      Eigen::Quaterniond orientation = mrs_lib::geometry::quaternionFromEuler(x2, y2, z2);
+
+      double radius = 0.3 * rand_dbl(generator);
+      double height = rand_dbl(generator);
+
+      double r = (x1 - range_min) / (range_max - range_min);
+      double g = (y1 - range_min) / (range_max - range_min);
+      double b = (z1 - range_min) / (range_max - range_min);
+
+      Cylinder cyl(center, radius, height, orientation);
+      double   timeout_sec = 0.2 * rand_percent(generator);
+      bv.addCylinder(cyl, r, g, b, 1.0, true, true, 12, ros::Duration(timeout_sec));
+      bv.addCylinder(cyl, 0, 0, 0, 1, false, false, 12, ros::Duration(timeout_sec));
+    }
+    bv.publish();
+    ros::spinOnce();
+    ros::Duration(0.05).sleep();
+  }
   ROS_INFO("[%s]: Done", ros::this_node::getName().c_str());
   //}
 

--- a/src/batch_visualizer/visual_object.cpp
+++ b/src/batch_visualizer/visual_object.cpp
@@ -1,4 +1,4 @@
-#include <mrs_lib/batch_visualizer/visual_object.h>
+#include <mrs_lib/visual_object.h>
 
 namespace mrs_lib
 {

--- a/src/batch_visualizer/visual_object.cpp
+++ b/src/batch_visualizer/visual_object.cpp
@@ -1,0 +1,317 @@
+#include <mrs_lib/batch_visualizer/visual_object.h>
+
+namespace mrs_lib
+{
+
+/* utils //{ */
+
+/* conversions //{ */
+geometry_msgs::Point eigenToMsg(const Eigen::Vector3d& v) {
+  geometry_msgs::Point p;
+  p.x = v.x();
+  p.y = v.y();
+  p.z = v.z();
+  return p;
+}
+
+std_msgs::ColorRGBA generateColor(const double r, const double g, const double b, const double a) {
+  std_msgs::ColorRGBA c;
+  c.r = r;
+  c.g = g;
+  c.b = b;
+  c.a = a;
+  return c;
+}
+
+Eigen::Vector3d msgToEigen(const geometry_msgs::Point& p) {
+  return Eigen::Vector3d(p.x, p.y, p.z);
+}
+//}
+
+/* buildEllipse //{ */
+std::vector<Eigen::Vector3d> buildEllipse(const mrs_lib::geometry::Ellipse& ellipse, const int num_points) {
+  std::vector<Eigen::Vector3d> points;
+  double                       theta = 0;
+  for (int i = 0; i < num_points; i++) {
+    double          nom = (ellipse.a() * ellipse.b());
+    double          den = sqrt(((ellipse.b() * cos(theta)) * (ellipse.b() * cos(theta))) + ((ellipse.a() * sin(theta)) * (ellipse.a() * sin(theta))));
+    double          rho = nom / den;
+    Eigen::Vector3d point(rho * cos(theta), rho * sin(theta), 0);
+    point = ellipse.center() + ellipse.orientation() * point;
+    points.push_back(point);
+    theta += 2.0 * M_PI / num_points;
+  }
+  return points;
+}
+//}
+
+//}
+
+/* addRay //{ */
+void VisualObject::addRay(const mrs_lib::geometry::Ray& ray, const double r, const double g, const double b, const double a) {
+  type_ = MarkerType::LINE;
+  points_.push_back(eigenToMsg(ray.p1()));
+  points_.push_back(eigenToMsg(ray.p2()));
+  colors_.push_back(generateColor(r, g, b, a));
+  colors_.push_back(generateColor(r, g, b, a));
+}
+//}
+
+/* addTriangle //{ */
+void VisualObject::addTriangle(const mrs_lib::geometry::Triangle& triangle, const double r, const double g, const double b, const double a, const bool filled) {
+  if (filled) {
+    type_ = MarkerType::TRIANGLE;
+    points_.push_back(eigenToMsg(triangle.a()));
+    points_.push_back(eigenToMsg(triangle.b()));
+    points_.push_back(eigenToMsg(triangle.c()));
+    colors_.push_back(generateColor(r, g, b, a));
+    colors_.push_back(generateColor(r, g, b, a));
+    colors_.push_back(generateColor(r, g, b, a));
+  } else {
+    type_ = MarkerType::LINE;
+    points_.push_back(eigenToMsg(triangle.a()));
+    points_.push_back(eigenToMsg(triangle.b()));
+    colors_.push_back(generateColor(r, g, b, a));
+    colors_.push_back(generateColor(r, g, b, a));
+
+    points_.push_back(eigenToMsg(triangle.b()));
+    points_.push_back(eigenToMsg(triangle.c()));
+    colors_.push_back(generateColor(r, g, b, a));
+    colors_.push_back(generateColor(r, g, b, a));
+
+    points_.push_back(eigenToMsg(triangle.c()));
+    points_.push_back(eigenToMsg(triangle.a()));
+    colors_.push_back(generateColor(r, g, b, a));
+    colors_.push_back(generateColor(r, g, b, a));
+  }
+}
+//}
+
+/* addEllipse //{ */
+void VisualObject::addEllipse(const mrs_lib::geometry::Ellipse& ellipse, const double r, const double g, const double b, const double a, const bool filled,
+                              const int num_points) {
+
+  std::vector<Eigen::Vector3d> points = buildEllipse(ellipse, num_points);
+  if (filled) {
+    for (int i = 0; i < num_points - 1; i++) {
+      mrs_lib::geometry::Triangle tri(ellipse.center(), points[i], points[i + 1]);
+      addTriangle(tri, r, g, b, a, true);
+    }
+    mrs_lib::geometry::Triangle tri(ellipse.center(), points[num_points - 1], points[0]);
+    addTriangle(tri, r, g, b, a, true);
+
+  } else {
+    for (int i = 0; i < num_points - 1; i++) {
+      mrs_lib::geometry::Ray ray = mrs_lib::geometry::Ray::twopointCast(points[i], points[i + 1]);
+      addRay(ray, r, g, b, a);
+    }
+    mrs_lib::geometry::Ray ray = mrs_lib::geometry::Ray::twopointCast(points[num_points - 1], points[0]);
+    addRay(ray, r, g, b, a);
+  }
+}
+//}
+
+/* Eigen::Vector3d //{ */
+VisualObject::VisualObject(const Eigen::Vector3d& point, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+                           const unsigned long& id)
+    : id_(id) {
+  type_ = MarkerType::POINT;
+  points_.push_back(eigenToMsg(point));
+  colors_.push_back(generateColor(r, g, b, a));
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Ray //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Ray& ray, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+                           const unsigned long& id)
+    : id_(id) {
+  type_ = MarkerType::LINE;
+  addRay(ray, r, g, b, a);
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Triangle //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Triangle& triangle, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const unsigned long& id)
+    : id_(id) {
+  addTriangle(triangle, r, g, b, a, filled);
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Rectangle //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Rectangle& rectangle, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const unsigned long& id)
+    : id_(id) {
+  for (const auto& t : rectangle.triangles()) {
+    addTriangle(t, r, g, b, a, filled);
+  }
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Cuboid //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Cuboid& cuboid, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const unsigned long& id)
+    : id_(id) {
+
+  for (int i = 0; i < 6; i++) {
+    for (const auto& t : cuboid.getRectangle(i).triangles()) {
+      addTriangle(t, r, g, b, a, filled);
+    }
+  }
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Ellipse//{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Ellipse& ellipse, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const unsigned long& id, const int num_points)
+    : id_(id) {
+  addEllipse(ellipse, r, g, b, a, filled, num_points);
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Cylinder //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Cylinder& cylinder, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const bool capped, const unsigned long& id, const int num_sides)
+    : id_(id) {
+  if (capped) {
+    mrs_lib::geometry::Ellipse top    = cylinder.getCap(mrs_lib::geometry::Cylinder::TOP);
+    mrs_lib::geometry::Ellipse bottom = cylinder.getCap(mrs_lib::geometry::Cylinder::BOTTOM);
+    addEllipse(top, r, g, b, a, filled, num_sides);
+    addEllipse(bottom, r, g, b, a, filled, num_sides);
+  }
+  std::vector<Eigen::Vector3d> top_points    = buildEllipse(cylinder.getCap(mrs_lib::geometry::Cylinder::TOP), num_sides);
+  std::vector<Eigen::Vector3d> bottom_points = buildEllipse(cylinder.getCap(mrs_lib::geometry::Cylinder::BOTTOM), num_sides);
+  for (unsigned int i = 0; i < top_points.size() - 1; i++) {
+    mrs_lib::geometry::Rectangle rect(bottom_points[i], bottom_points[i + 1], top_points[i + 1], top_points[i]);
+    addTriangle(rect.triangles()[0], r, g, b, a, filled);
+    addTriangle(rect.triangles()[1], r, g, b, a, filled);
+  }
+  mrs_lib::geometry::Rectangle rect(bottom_points[bottom_points.size() - 1], bottom_points[0], top_points[0], top_points[top_points.size() - 1]);
+  addTriangle(rect.triangles()[0], r, g, b, a, filled);
+  addTriangle(rect.triangles()[1], r, g, b, a, filled);
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_lib::geometry::Cone //{ */
+VisualObject::VisualObject(const mrs_lib::geometry::Cone& cone, const double r, const double g, const double b, const double a, const ros::Duration& timeout,
+                           const bool filled, const bool capped, const unsigned long& id, const int num_sides)
+    : id_(id) {
+  if (capped) {
+    mrs_lib::geometry::Ellipse cap = cone.getCap();
+    addEllipse(cap, r, g, b, a, filled, num_sides);
+  }
+  std::vector<Eigen::Vector3d> cap_points = buildEllipse(cone.getCap(), num_sides);
+  for (unsigned int i = 0; i < cap_points.size() - 1; i++) {
+    mrs_lib::geometry::Triangle tri(cap_points[i], cap_points[i + 1], cone.origin());
+    addTriangle(tri, r, g, b, a, filled);
+  }
+  mrs_lib::geometry::Triangle tri(cap_points[cap_points.size() - 1], cap_points[0], cone.origin());
+  addTriangle(tri, r, g, b, a, filled);
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* mrs_msgs::TrajectoryReference //{ */
+VisualObject::VisualObject(const mrs_msgs::TrajectoryReference& traj, const double r, const double g, const double b, const double a,
+                           const ros::Duration& timeout, const bool filled, const unsigned long& id)
+    : id_(id) {
+  if (traj.points.size() < 2) {
+    return;
+  }
+  if (filled) {
+    for (size_t i = 0; i < traj.points.size() - 1; i++) {
+      Eigen::Vector3d p1, p2;
+      p1.x()   = traj.points[i].position.x;
+      p1.y()   = traj.points[i].position.y;
+      p1.z()   = traj.points[i].position.z;
+      p2.x()   = traj.points[i + 1].position.x;
+      p2.y()   = traj.points[i + 1].position.y;
+      p2.z()   = traj.points[i + 1].position.z;
+      auto ray = mrs_lib::geometry::Ray::twopointCast(p1, p2);
+      addRay(ray, r, g, b, a);
+    }
+  } else {
+    type_ = MarkerType::POINT;
+    for (size_t i = 0; i < traj.points.size(); i++) {
+      points_.push_back(traj.points[i].position);
+      colors_.push_back(generateColor(r, g, b, a));
+    }
+  }
+  if (timeout.toSec() <= 0) {
+    timeout_time_ = ros::Time(0);
+  } else {
+    timeout_time_ = ros::Time::now() + timeout;
+  }
+}
+//}
+
+/* getID //{ */
+unsigned long VisualObject::getID() const {
+  return id_;
+}
+//}
+
+/* getType //{ */
+int VisualObject::getType() const {
+  return type_;
+}
+//}
+
+/* isTimedOut //{ */
+bool VisualObject::isTimedOut() const {
+  return !timeout_time_.isZero() && (timeout_time_ - ros::Time::now()).toSec() <= 0;
+}
+//}
+
+/* getPoints //{ */
+const std::vector<geometry_msgs::Point> VisualObject::getPoints() const {
+  return points_;
+}
+//}
+
+/* getColors //{ */
+const std::vector<std_msgs::ColorRGBA> VisualObject::getColors() const {
+  return colors_;
+}
+//}
+
+}  // namespace mrs_lib


### PR DESCRIPTION
Based on the request here https://github.com/ctu-mrs/mrs_lib/issues/42, added a timeout option for all `add...` methods in BatchVisualizer. Use `ros::Duration(seconds)` as the last argument, to set a timeout duration. All timed-out objects are cleared by calling the `publish()` method. Default timeout is ros::Duration(0) -> no timeout.

Known limitations:
The visualizer buffer now has to keep unique IDs for all objects, the theoretical limit for added objects in one session is unsigned long max (4294967295 items).