### PR TITLE
Fix for a missing explicit include of <atomic> causing a compilation error on armhf/arm64 platforms.

### DIFF
--- a/include/mrs_lib/publisher_handler.h
+++ b/include/mrs_lib/publisher_handler.h
@@ -8,6 +8,7 @@
 #include <ros/ros.h>
 #include <ros/package.h>
 
+#include <atomic>
 #include <string>
 #include <mutex>
 


### PR DESCRIPTION
A simple fix for a missing explicit include of `<atomic>` in the header file **publisher_handler.h.** It doesn't seem to be a problem on amd64/x86 architectures but the catkin build of this package fails on armhf/arm64 (tested on Raspberry Pi 3A and 4B):
```
In file included from /home/mrs/catkin_ws/src/mrs_lib/include/mrs_lib/dynamic_publisher.h:13,
                 from /home/mrs/catkin_ws/src/mrs_lib/src/dynamic_publisher/dynamic_publisher.cpp:1:
/home/mrs/catkin_ws/src/mrs_lib/include/mrs_lib/publisher_handler.h:79:21: error: field ‘publisher_initialized_’ has incomplete type ‘std::atomic<bool>’
   79 |   std::atomic<bool> publisher_initialized_;
      |                     ^~~~~~~~~~~~~~~~~~~~~~
In file included from /usr/include/c++/10/bits/shared_ptr_atomic.h:33,
                 from /usr/include/c++/10/memory:85,
                 from /usr/include/boost/smart_ptr/detail/sp_counted_impl.hpp:35,
                 from /usr/include/boost/smart_ptr/detail/shared_count.hpp:27,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:17,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /opt/ros/noetic/include/ros/forwards.h:37,
                 from /opt/ros/noetic/include/ros/common.h:37,
                 from /opt/ros/noetic/include/ros/ros.h:43,
                 from /home/mrs/catkin_ws/src/mrs_lib/include/mrs_lib/dynamic_publisher.h:12,
                 from /home/mrs/catkin_ws/src/mrs_lib/src/dynamic_publisher/dynamic_publisher.cpp:1:
/usr/include/c++/10/bits/atomic_base.h:152:12: note: declaration of ‘struct std::atomic<bool>’
  152 |     struct atomic;
      |            ^~~~~~
make[2]: *** [CMakeFiles/MrsLibDynamicPublisher.dir/build.make:82: CMakeFiles/MrsLibDynamicPublisher.dir/src/dynamic_publisher/dynamic_publisher.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:5584: CMakeFiles/MrsLibDynamicPublisher.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
make: *** [Makefile:160: all] Error 2
```

GCC/G++ version: gcc (Debian 10.2.1-6) 10.2.1 20210110
Make version: GNU Make 4.3 for aarch64-unknown-linux-gnu
CMake version: 3.18.4