### PR TITLE
Adding interface to change the callback post-initialization

### DIFF
--- a/include/mrs_lib/impl/timer.hpp
+++ b/include/mrs_lib/impl/timer.hpp
@@ -37,6 +37,7 @@ public:
   void start();
   void stop();
   void setPeriod(const ros::Duration& duration, const bool reset = true);
+  void setCallback(const std::function<void(const ros::TimerEvent&)>& callback);
 
   friend class ThreadTimer;
 

--- a/include/mrs_lib/timer.h
+++ b/include/mrs_lib/timer.h
@@ -44,10 +44,11 @@ namespace mrs_lib
     virtual void setPeriod(const ros::Duration& duration, const bool reset = true) = 0;
 
     /**
-     * @brief set the timer period/duration
+     * @brief change the callback method 
      *
-     * @param duration
-     * @param reset
+     * Usable e.g. for running thread with a specific parameter if you bind it using std::bind
+     *
+     * @param callback          callback method to be called.
      */
     virtual void setCallback(const std::function<void(const ros::TimerEvent&)>& callback) = 0;
 
@@ -218,12 +219,11 @@ namespace mrs_lib
     virtual void setPeriod(const ros::Duration& duration, const bool reset = true) override;
     
     /**
-     * @brief set the callback function
+     * @brief change the callback method
      *
-     * Usable e.g. for running thread with a specific parameter
+     * Usable e.g. for running thread with a specific parameter if you bind it using std::bind
      *
-     * @param ObjectType::*const callback   callback method to be called.
-     * @param obj                           object for the method.
+     * @param callback          callback method to be called.
      */
     virtual void setCallback(const std::function<void(const ros::TimerEvent&)>& callback) override;
 

--- a/include/mrs_lib/timer.h
+++ b/include/mrs_lib/timer.h
@@ -44,6 +44,14 @@ namespace mrs_lib
     virtual void setPeriod(const ros::Duration& duration, const bool reset = true) = 0;
 
     /**
+     * @brief set the timer period/duration
+     *
+     * @param duration
+     * @param reset
+     */
+    virtual void setCallback(const std::function<void(const ros::TimerEvent&)>& callback) = 0;
+
+    /**
      * @brief returns true if callbacks should be called
      *
      * @return true if timer is running
@@ -208,6 +216,16 @@ namespace mrs_lib
      * @param reset    ignored in this implementation.
      */
     virtual void setPeriod(const ros::Duration& duration, const bool reset = true) override;
+    
+    /**
+     * @brief set the callback function
+     *
+     * Usable e.g. for running thread with a specific parameter
+     *
+     * @param ObjectType::*const callback   callback method to be called.
+     * @param obj                           object for the method.
+     */
+    virtual void setCallback(const std::function<void(const ros::TimerEvent&)>& callback) override;
 
     /**
      * @brief returns true if callbacks should be called

--- a/src/timer/timer.cpp
+++ b/src/timer/timer.cpp
@@ -170,6 +170,8 @@ void ThreadTimer::Impl::setPeriod(const ros::Duration& duration, [[maybe_unused]
 }
 
 void ThreadTimer::Impl::setCallback(const std::function<void(const ros::TimerEvent&)>& callback){
+  std::scoped_lock lock(mutex_state_);
+
   callback_ = callback;
 }
 

--- a/src/timer/timer.cpp
+++ b/src/timer/timer.cpp
@@ -93,6 +93,16 @@ void ThreadTimer::setPeriod(const ros::Duration& duration, [[maybe_unused]] cons
 
 //}
 
+/* ThreadTimer::setCallback() //{ */
+
+void ThreadTimer::setCallback(const std::function<void(const ros::TimerEvent&)>& callback) {
+  if (impl_) {
+    impl_->setCallback(callback);
+  }
+}
+
+//}
+
 /* ThreadTimer::running() //{ */
 
 bool ThreadTimer::running()
@@ -157,6 +167,10 @@ void ThreadTimer::Impl::setPeriod(const ros::Duration& duration, [[maybe_unused]
   // gracefully handle the special case
   if (duration == ros::Duration(0))
     this->oneshot_  = true;
+}
+
+void ThreadTimer::Impl::setCallback(const std::function<void(const ros::TimerEvent&)>& callback){
+  callback_ = callback;
 }
 
 //}


### PR DESCRIPTION
This is useful in cases such as if I want to give the callback parameters without need for setting and mutexing global variables.