### PR TITLE
[Transformer]: fixed UTMtoLL to fill out the correct frame

### DIFF
--- a/src/transformer/transformer.cpp
+++ b/src/transformer/transformer.cpp
@@ -490,7 +490,7 @@ namespace mrs_lib
     return utm;
   }
 
-  geometry_msgs::PointStamped Transformer::LLtoUTM(const geometry_msgs::PointStamped& what, [[maybe_unused]] const std::string& prefix)
+  geometry_msgs::PointStamped Transformer::LLtoUTM(const geometry_msgs::PointStamped& what, const std::string& prefix)
   {
     geometry_msgs::PointStamped ret;
     ret.header.frame_id = prefix + "utm_origin";
@@ -534,14 +534,14 @@ namespace mrs_lib
     return latlon;
   }
 
-  std::optional<geometry_msgs::PointStamped> Transformer::UTMtoLL(const geometry_msgs::PointStamped& what, [[maybe_unused]] const std::string& prefix)
+  std::optional<geometry_msgs::PointStamped> Transformer::UTMtoLL(const geometry_msgs::PointStamped& what, const std::string& prefix)
   {
     const auto opt = UTMtoLL(what.point, prefix);
     if (!opt.has_value())
       return std::nullopt;
 
     geometry_msgs::PointStamped ret;
-    ret.header.frame_id = prefix + "utm_origin";
+    ret.header.frame_id = prefix + LATLON_ORIGIN;
     ret.header.stamp = what.header.stamp;
     ret.point = opt.value();
     return ret;
@@ -566,7 +566,7 @@ namespace mrs_lib
       return std::nullopt;
 
     geometry_msgs::PoseStamped ret;
-    ret.header.frame_id = prefix + "utm_origin";
+    ret.header.frame_id = prefix + LATLON_ORIGIN;
     ret.header.stamp = what.header.stamp;
     ret.pose = opt.value();
     return ret;


### PR DESCRIPTION
Minor fix in the Transformer to correctly fill out the resulting header when transforming **to** the latitude-longitude frame.