### PR TITLE
Fix mrs_lib::Node API to better match rclcpp::Node

### DIFF
--- a/include/mrs_lib/node.h
+++ b/include/mrs_lib/node.h
@@ -11,28 +11,31 @@ namespace mrs_lib
 class Node {
 
 protected:
-  Node(const std::string& node_name, const rclcpp::NodeOptions& options = rclcpp::NodeOptions()) : node_(std::make_shared<rclcpp::Node>(node_name, options)) {
+  explicit Node(const std::string& node_name, const rclcpp::NodeOptions& options = rclcpp::NodeOptions()) : node_(std::make_shared<rclcpp::Node>(node_name, options)) {
   }
 
-  Node(const std::string& node_name, const std::string& namespace_, const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+  explicit Node(const std::string& node_name, const std::string& namespace_, const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
       : node_(std::make_shared<rclcpp::Node>(node_name, namespace_, options)) {
   }
 
   ~Node()                      = default;
-  Node(const Node&)            = default;
-  Node& operator=(const Node&) = default;
-  Node(Node&&)                 = default;
-  Node& operator=(Node&&)      = default;
+  Node(const Node&)            = delete;
+  Node& operator=(const Node&) = delete;
+  Node(Node&&)                 = delete;
+  Node& operator=(Node&&)      = delete;
 
-  rclcpp::Node& this_node() {
+  [[nodiscard]] rclcpp::Node& this_node() noexcept {
     return *node_;
   }
-  rclcpp::Node::SharedPtr this_node_ptr() const {
+  [[nodiscard]] const rclcpp::Node& this_node() const noexcept {
+    return *node_;
+  }
+  [[nodiscard]] rclcpp::Node::SharedPtr this_node_ptr() const noexcept {
     return node_;
   }
 
 public:
-  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_node_base_interface() const {
+  rclcpp::node_interfaces::NodeBaseInterface::SharedPtr get_node_base_interface() {
     return node_->get_node_base_interface();
   }
 


### PR DESCRIPTION
- marked constructors explicit
- deleted copy and move operations
- removed const qualifier from `get_node_base_interface`

additions:
- added const qualified overload for `this_node`
- marked the accessors `[[nodiscard]]` and `noexcept`