### PR TITLE
Add coroutines and awaitable service

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ target_sources(mrs_lib_mrs_lib
     # src/batch_visualizer
     "src/batch_visualizer/batch_visualizer.cpp"
     "src/batch_visualizer/visual_object.cpp"
+    # src/coro/internal
+    "src/coro/internal/thread_local_continuation_scheduler.cpp"
     # src/dynparam_mgr
     "src/dynparam_mgr/dynparam_mgr.cpp"
     # src/geometry
@@ -155,6 +157,13 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/ukf.h"
     "include/mrs_lib/utils.h"
     "include/mrs_lib/visual_object.h"
+    # include/mrs_lib/coro
+    "include/mrs_lib/coro/runners.hpp"
+    "include/mrs_lib/coro/task.hpp"
+    "include/mrs_lib/coro/task.impl.hpp"
+    # include/mrs_lib/coro/internal
+    "include/mrs_lib/coro/internal/attributes.hpp"
+    "include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
     # include/mrs_lib/geometry
     "include/mrs_lib/geometry/conversions_eigen.h"
     "include/mrs_lib/geometry/conversions.h"
@@ -172,6 +181,8 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/impl/timer_handler.hpp"
     "include/mrs_lib/impl/transformer.hpp"
     "include/mrs_lib/impl/ukf.hpp"
+    # include/mrs_lib/internal
+    "include/mrs_lib/internal/coroutine_callback_helpers.hpp"
     # include/mrs_lib/safety_zone
     "include/mrs_lib/safety_zone/line_operations.h"
     "include/mrs_lib/safety_zone/polygon.h"

--- a/include/mrs_lib/coro/internal/attributes.hpp
+++ b/include/mrs_lib/coro/internal/attributes.hpp
@@ -1,0 +1,14 @@
+#ifndef MRS_LIB_CORO_INTERNAL_ATTRIBUTES_HPP_
+#define MRS_LIB_CORO_INTERNAL_ATTRIBUTES_HPP_
+
+#ifdef __clang__
+#define MRS_LIB_INTERNAL_CORO_RETURN_TYPE [[clang::coro_return_type]]
+#define MRS_LIB_INTERNAL_CORO_WRAPPER [[clang::coro_wrapper]]
+#define MRS_LIB_INTERNAL_CORO_LIFETIMEBOUND [[clang::coro_lifetimebound]]
+#else
+#define MRS_LIB_INTERNAL_CORO_RETURN_TYPE
+#define MRS_LIB_INTERNAL_CORO_WRAPPER
+#define MRS_LIB_INTERNAL_CORO_LIFETIMEBOUND
+#endif
+
+#endif // MRS_LIB_CORO_INTERNAL_ATTRIBUTES_HPP_

--- a/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
+++ b/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
@@ -1,0 +1,45 @@
+#ifndef MRS_LIB_CORO_INTERNAL_THREAD_LOCAL_CONTINUATION_SCHEDULER_HPP_
+#define MRS_LIB_CORO_INTERNAL_THREAD_LOCAL_CONTINUATION_SCHEDULER_HPP_
+
+
+#include <coroutine>
+
+namespace mrs_lib::internal
+{
+
+  // This is a workaround to GCC generated code overflowing stack when using symmetric transfer
+
+  void resume_coroutine(std::coroutine_handle<> handle);
+  void schedule_coroutine_continuation(std::coroutine_handle<> handle);
+
+  struct MoveToThreadLocalContinuationScheduler
+  {
+    MoveToThreadLocalContinuationScheduler() = default;
+    ~MoveToThreadLocalContinuationScheduler() = default;
+    MoveToThreadLocalContinuationScheduler(const MoveToThreadLocalContinuationScheduler&) = delete;
+    MoveToThreadLocalContinuationScheduler& operator=(const MoveToThreadLocalContinuationScheduler&) = delete;
+    MoveToThreadLocalContinuationScheduler(MoveToThreadLocalContinuationScheduler&&) = delete;
+    MoveToThreadLocalContinuationScheduler& operator=(MoveToThreadLocalContinuationScheduler&&) = delete;
+
+    // Always suspend the task
+    bool await_ready() noexcept
+    {
+      return false;
+    }
+
+    // Move the task to the thread local scheduler
+    void await_suspend(std::coroutine_handle<> task_handle) noexcept
+    {
+      resume_coroutine(task_handle);
+    }
+
+    // The task is moved, return nothing
+    void await_resume() noexcept
+    {
+    }
+  };
+
+} // namespace mrs_lib::internal
+
+
+#endif // MRS_LIB_CORO_INTERNAL_THREAD_LOCAL_CONTINUATION_SCHEDULER_HPP_

--- a/include/mrs_lib/coro/runners.hpp
+++ b/include/mrs_lib/coro/runners.hpp
@@ -1,0 +1,92 @@
+#ifndef MRS_LIB_CORO_RUNNERS_HPP_
+#define MRS_LIB_CORO_RUNNERS_HPP_
+
+#include <concepts>
+#include <coroutine>
+
+#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
+#include <mrs_lib/coro/task.hpp>
+
+
+namespace mrs_lib
+{
+
+  namespace internal
+  {
+
+    /**
+     * @brief Coroutine type used to start asynchronous computation.
+     *
+     * Calling a coroutine that returns this type runs until the first
+     * suspension inside the body. After that, it is up to the awaitables to
+     * resume or cancel the started coroutine.
+     */
+    class AsyncRun
+    {
+    public:
+      struct promise_type
+      {
+        AsyncRun get_return_object()
+        {
+          return AsyncRun();
+        }
+        MoveToThreadLocalContinuationScheduler initial_suspend()
+        {
+          return {};
+        }
+        std::suspend_never final_suspend() noexcept
+        {
+          return {};
+        }
+        void return_void()
+        {
+        }
+        void unhandled_exception()
+        {
+          throw;
+        }
+      };
+
+    private:
+      AsyncRun() = default;
+    };
+
+    template <class T>
+      requires std::convertible_to<T, std::decay_t<T>>
+    constexpr std::decay_t<T> decay_copy(T&& value) noexcept(std::is_nothrow_convertible_v<T, std::decay_t<T>>)
+    {
+      return std::forward<T>(value);
+    }
+
+    template <typename F, typename... Args>
+      requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
+    internal::AsyncRun start_task_impl(F&& task, Args&&... args)
+    {
+      // The `decay-copy` of the arguments ensures that they are copied into
+      // the coroutine frame, preventing dangling references like `std::thread`.
+      co_await std::invoke(decay_copy(std::forward<F>(task)), decay_copy(std::forward<Args>(args))...);
+    }
+
+  } // namespace internal
+
+  /**
+   * @brief Start execution of a task from outside of a coroutine.
+   *
+   * This function starts the execution of the coroutine using the provided
+   * arguments. The passed arguments are decay-copied into the coroutine frame
+   * (similarly to std::thread).
+   *
+   * Using this function from user code is not usually necessary. It can be
+   * avoided by `co_await`ing the tasks and using callbacks that support passing
+   * coroutine callbacks.
+   */
+  template <typename F, typename... Args>
+    requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
+  void start_task(F&& task, Args&&... args)
+  {
+    internal::start_task_impl(std::forward<F>(task), std::forward<Args>(args)...);
+  }
+
+} // namespace mrs_lib
+
+#endif // MRS_LIB_CORO_RUNNERS_HPP_

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -1,0 +1,345 @@
+#ifndef MRS_LIB_CORO_TASK_HPP_
+#define MRS_LIB_CORO_TASK_HPP_
+
+#include <cassert>
+#include <concepts>
+#include <coroutine>
+#include <functional>
+#include <memory>
+#include <type_traits>
+#include <utility>
+
+#include <mrs_lib/coro/internal/attributes.hpp>
+
+// Note on ownership semantics:
+// Since we want to support cancellation at any point in the coroutine stacks,
+// each coroutine is owned by the object responsible for resuming it. If the
+// coroutine is running, it is responsible for it's own lifetime - it has to
+// either suspend and become continuation of some other task thus transferring
+// ownership or destruct itself once completed.
+
+namespace mrs_lib
+{
+
+  template <typename T = void>
+    requires(std::same_as<T, std::remove_cvref_t<T>>)
+  class Task;
+
+  namespace internal
+  {
+
+    /**
+     * @brief Deleter for std::unique_ptr that stores a coroutine handle.
+     */
+    template <typename T>
+    struct CoroutineDestroyer
+    {
+      void operator()(std::coroutine_handle<T> handle)
+      {
+        handle.destroy();
+      }
+      using pointer = std::coroutine_handle<T>;
+    };
+
+    template <typename T = void>
+    using OwningCoroutineHandle = std::unique_ptr<std::coroutine_handle<T>, CoroutineDestroyer<T>>;
+
+    /**
+     * @brief RAII class to destroy a coroutine at the end of a scope.
+     */
+    template <typename T>
+    class DeferredCoroutineDestroyer
+    {
+    public:
+      DeferredCoroutineDestroyer(std::coroutine_handle<T> handle) : handle_(handle)
+      {
+      }
+      ~DeferredCoroutineDestroyer()
+      {
+        std::invoke(CoroutineDestroyer<T>{}, handle_);
+      }
+      DeferredCoroutineDestroyer(const DeferredCoroutineDestroyer&) = delete;
+      DeferredCoroutineDestroyer& operator=(const DeferredCoroutineDestroyer&) = delete;
+      DeferredCoroutineDestroyer(DeferredCoroutineDestroyer&&) = delete;
+      DeferredCoroutineDestroyer& operator=(DeferredCoroutineDestroyer&&) = delete;
+
+    private:
+      std::coroutine_handle<T> handle_;
+    };
+
+    /**
+     * @brief Base class for the task's promise type.
+     *
+     * This implements the promise type interface that is common for both void
+     * and non-void tasks.
+     */
+    template <typename Derived>
+    class BasePromiseType
+    {
+      /**
+       * @brief Awaitable used for final_suspend of mrs_lib::Task
+       *
+       * This class is responsible for resuming continuation of the completed task.
+       */
+      class FinalAwaitable
+      {
+      public:
+        FinalAwaitable() = default;
+        ~FinalAwaitable() = default;
+        FinalAwaitable(const FinalAwaitable&) = delete;
+        FinalAwaitable& operator=(const FinalAwaitable&) = delete;
+        FinalAwaitable(FinalAwaitable&&) = delete;
+        FinalAwaitable& operator=(FinalAwaitable&&) = delete;
+
+        // Always suspend the ending task
+        bool await_ready() noexcept;
+
+        // SYMMETRIC TRANSFER IS BROKEN IN GCC and can result in stack
+        // overflow when many tasks complete synchronously.
+        // Because of this problem, the `await_suspend` uses the void signature
+        // and resumes the continuation on a thread-local scheduler as a workaround.
+        void await_suspend(std::coroutine_handle<Derived> task_handle) noexcept;
+
+        // This should be unreachable - ended task should not be resumed
+        void await_resume() noexcept;
+      };
+
+    public:
+      // The task is lazy and will only start when awaited
+      std::suspend_always initial_suspend();
+      // The coroutine will be suspended and the continuation will be resumed
+      FinalAwaitable final_suspend() noexcept;
+
+      void set_continuation(OwningCoroutineHandle<> continuation);
+
+    private:
+      OwningCoroutineHandle<> continuation_{std::noop_coroutine()};
+    };
+
+    /**
+     * @brief A variant-like class for storing the result of non-void task.
+     */
+    template <typename T>
+    class ResultStorage
+    {
+    private:
+      enum class State
+      {
+        empty,
+        value,
+        exception,
+      };
+
+    public:
+      constexpr ResultStorage() noexcept : state_(State::empty)
+      {
+      }
+
+      /**
+       * @brief Store result of task.
+       *
+       * This can only ve called once and not if set_exception was called.
+       */
+      constexpr void set_value(T&& val) noexcept(std::is_nothrow_move_constructible_v<T>)
+      {
+        assert(state_ == State::empty);
+        std::construct_at(&value_, std::move(val));
+        state_ = State::value;
+      }
+
+      /**
+       * @brief Store exception into the result.
+       *
+       * This can only ve called once and not if set_value was called.
+       */
+      void set_exception(std::exception_ptr eptr) noexcept
+      {
+        assert(state_ == State::empty);
+        std::construct_at(&exception_, std::move(eptr));
+        state_ = State::exception;
+      }
+
+      /**
+       * @brief Get previously stored result or exception.
+       *
+       * If this result contains a value, it is returned. Otherwise, if there is
+       * an exception stored, it is thrown.
+       *
+       * Either set_value or set_exception must be called before calling this.
+       */
+      constexpr T get_value() &&
+      {
+        if (state_ == State::exception)
+        {
+          std::rethrow_exception(exception_);
+        }
+        assert(state_ == State::value);
+        return std::move(value_);
+      }
+
+      constexpr ~ResultStorage()
+      {
+        switch (state_)
+        {
+        case State::empty:
+          break;
+        case State::value:
+          std::destroy_at(&value_);
+          break;
+        case State::exception:
+          std::destroy_at(&exception_);
+          break;
+        }
+      }
+
+    private:
+      union
+      {
+        T value_;
+        std::exception_ptr exception_;
+      };
+      State state_;
+    };
+
+    /**
+     * @brief Promise type for non-void task.
+     *
+     * This is responsible for returning value from completed task.
+     */
+    template <typename T>
+    class PromiseType : public BasePromiseType<PromiseType<T>>
+    {
+    public:
+      Task<T> get_return_object();
+
+      void return_value(T&& ret_val);
+
+      void unhandled_exception();
+
+      T get_value()
+      {
+        return std::move(result_).get_value();
+      }
+
+    private:
+      ResultStorage<T> result_;
+    };
+
+    /**
+     * @brief Promise type for void task.
+     *
+     * This is responsible for returning void from completed task.
+     */
+    template <>
+    class PromiseType<void> : public BasePromiseType<PromiseType<void>>
+    {
+    public:
+      Task<void> get_return_object();
+
+      void return_void();
+
+      void unhandled_exception();
+
+      void get_value()
+      {
+        if (exception_)
+        {
+          std::rethrow_exception(exception_);
+        }
+      }
+
+    private:
+      std::exception_ptr exception_;
+    };
+
+    /**
+     * @brief Awaitable used to co_await other tasks.
+     *
+     * This is responsible for suspending the caller and registering it as
+     * a continuation of the callee.
+     */
+    template <typename T>
+    class TaskAwaitable
+    {
+      using Promise = Task<T>::promise_type;
+
+    public:
+      bool await_ready()
+      {
+        return false;
+      }
+
+      std::coroutine_handle<> await_suspend(std::coroutine_handle<> continuation)
+      {
+        task_handle_.promise().set_continuation(OwningCoroutineHandle<>(continuation));
+        return task_handle_;
+      }
+
+      T await_resume()
+      {
+        DeferredCoroutineDestroyer destroyer{this->task_handle_};
+        return this->task_handle_.promise().get_value();
+      }
+
+      ~TaskAwaitable() = default;
+      TaskAwaitable(const TaskAwaitable&) = delete;
+      TaskAwaitable& operator=(const TaskAwaitable&) = delete;
+      TaskAwaitable(TaskAwaitable&&) = delete;
+      TaskAwaitable& operator=(TaskAwaitable&&) = delete;
+
+    protected:
+      TaskAwaitable(std::coroutine_handle<Promise> task_handle) : task_handle_(task_handle)
+      {
+      }
+
+    protected:
+      std::coroutine_handle<Promise> task_handle_;
+
+      friend class Task<T>;
+    };
+
+  } // namespace internal
+
+  /**
+   * @brief Task type for creating coroutines.
+   *
+   * @tparam T Return type of the coroutine (default is void)
+   *
+   * Task is lazy coroutine, which means it must be `co_awaited` to start
+   * executing.
+   */
+  template <typename T>
+    requires(std::same_as<T, std::remove_cvref_t<T>>)
+  class [[nodiscard("Task is lazy and does not run until `co_await`ed.")]] MRS_LIB_INTERNAL_CORO_RETURN_TYPE MRS_LIB_INTERNAL_CORO_LIFETIMEBOUND Task
+  {
+  public:
+    using promise_type = internal::PromiseType<T>;
+
+    ~Task() = default;
+    Task(const Task&) = delete;
+    Task& operator=(const Task&) = delete;
+    Task(Task&&) = delete;
+    Task& operator=(Task&&) = delete;
+
+    friend internal::TaskAwaitable<T> operator co_await(Task task)
+    {
+      return internal::TaskAwaitable<T>(task.coroutine_.release());
+    }
+
+  private:
+    Task(internal::OwningCoroutineHandle<promise_type> coroutine) : coroutine_(std::move(coroutine))
+    {
+    }
+
+    internal::OwningCoroutineHandle<promise_type> coroutine_;
+
+    friend class internal::PromiseType<T>;
+  };
+
+} // namespace mrs_lib
+
+#ifndef MRS_LIB_CORO_TASK_IMPL_HPP_
+#include <mrs_lib/coro/task.impl.hpp> // IWYU pragma: export
+#endif
+
+#endif // MRS_LIB_CORO_TASK_HPP_

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -287,12 +287,11 @@ namespace mrs_lib
       TaskAwaitable(TaskAwaitable&&) = delete;
       TaskAwaitable& operator=(TaskAwaitable&&) = delete;
 
-    protected:
+    private:
       TaskAwaitable(std::coroutine_handle<Promise> task_handle) : task_handle_(task_handle)
       {
       }
 
-    protected:
       std::coroutine_handle<Promise> task_handle_;
 
       friend class Task<T>;

--- a/include/mrs_lib/coro/task.impl.hpp
+++ b/include/mrs_lib/coro/task.impl.hpp
@@ -1,0 +1,85 @@
+#ifndef MRS_LIB_CORO_TASK_IMPL_HPP_
+#define MRS_LIB_CORO_TASK_IMPL_HPP_
+
+#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
+#include <mrs_lib/coro/task.hpp>
+
+namespace mrs_lib
+{
+  namespace internal
+  {
+
+    template <typename Derived>
+    inline bool BasePromiseType<Derived>::FinalAwaitable::await_ready() noexcept
+    {
+      return false;
+    }
+
+    template <typename Derived>
+    inline void BasePromiseType<Derived>::FinalAwaitable::await_suspend(std::coroutine_handle<Derived> task_handle) noexcept
+    {
+      // Destructor of task would destroy the continuation so we need to release the continuation
+      schedule_coroutine_continuation(task_handle.promise().continuation_.release());
+    }
+
+    template <typename Derived>
+    inline void BasePromiseType<Derived>::FinalAwaitable::await_resume() noexcept
+    {
+      assert(false);
+    }
+
+    template <typename Derived>
+    inline std::suspend_always BasePromiseType<Derived>::initial_suspend()
+    {
+      return {};
+    }
+
+    template <typename Derived>
+    inline auto BasePromiseType<Derived>::final_suspend() noexcept -> FinalAwaitable
+    {
+      return {};
+    }
+
+    template <typename Derived>
+    inline void BasePromiseType<Derived>::set_continuation(OwningCoroutineHandle<> continuation)
+    {
+      continuation_ = std::move(continuation);
+    }
+
+    template <typename T>
+    Task<T> PromiseType<T>::get_return_object()
+    {
+      return Task<T>(OwningCoroutineHandle<PromiseType>(std::coroutine_handle<PromiseType>::from_promise(*this)));
+    }
+
+    template <typename T>
+    void PromiseType<T>::return_value(T&& ret_val)
+    {
+      result_.set_value(std::move(ret_val));
+    }
+
+    template <typename T>
+    void PromiseType<T>::unhandled_exception()
+    {
+      result_.set_exception(std::current_exception());
+    }
+
+    inline Task<void> PromiseType<void>::get_return_object()
+    {
+      return Task<void>(OwningCoroutineHandle<PromiseType>(std::coroutine_handle<PromiseType>::from_promise(*this)));
+    }
+
+    inline void PromiseType<void>::return_void()
+    {
+    }
+
+    inline void PromiseType<void>::unhandled_exception()
+    {
+      exception_ = std::current_exception();
+    }
+
+  } // namespace internal
+} // namespace mrs_lib
+
+
+#endif // MRS_LIB_CORO_TASK_IMPL_HPP_

--- a/include/mrs_lib/impl/service_client_handler.hpp
+++ b/include/mrs_lib/impl/service_client_handler.hpp
@@ -10,6 +10,167 @@
 namespace mrs_lib
 {
 
+  namespace internal
+  {
+
+    template <typename ServiceType>
+      requires(rosidl_generator_traits::is_service<ServiceType>::value)
+    class [[nodiscard("This service call is only performed when `co_await`ed.")]] ServiceAwaitable
+    {
+      using Client = rclcpp::Client<ServiceType>;
+      using Response = ServiceType::Response;
+      using Request = ServiceType::Request;
+
+    public:
+      ServiceAwaitable(const ServiceAwaitable&) = delete;
+      ServiceAwaitable& operator=(const ServiceAwaitable&) = delete;
+      ServiceAwaitable(ServiceAwaitable&&) = delete;
+      ServiceAwaitable& operator=(ServiceAwaitable&&) = delete;
+
+      bool await_ready()
+      {
+        return false;
+      }
+
+      bool await_suspend(std::coroutine_handle<> continuation)
+      {
+        // Store the continuation into the awaitable.
+        // It will either be invoked when the service completes or destroyed if it is cancelled.
+        data_.continuation = continuation;
+        std::shared_ptr<Client> client = data_.client.lock();
+        if (client == nullptr || !client->service_is_ready())
+        {
+          data_.response = std::nullopt;
+          // Do not suspend
+          return false;
+        }
+        client->async_send_request(data_.request,
+                                   std::function([data_handle = DataHandle(data_)](std::shared_future<std::shared_ptr<Response>> future) mutable {
+                                     auto data = data_handle.leak();
+                                     data->response = future.get();
+                                     (*data).response = future.get();
+                                     auto continuation = std::exchange(data->continuation, nullptr);
+                                     internal::resume_coroutine(continuation);
+                                   }));
+        return true;
+      }
+
+      std::optional<std::shared_ptr<Response>> await_resume()
+      {
+        return data_.response;
+      }
+
+    private:
+      ServiceAwaitable(std::weak_ptr<Client> client, std::shared_ptr<Request> request)
+          : data_{
+                .client = std::move(client),
+                .request = std::move(request),
+            }
+      {
+      }
+
+      struct Data
+      {
+        std::weak_ptr<Client> client;
+        std::shared_ptr<Request> request;
+        std::optional<std::shared_ptr<Response>> response = std::nullopt;
+        std::coroutine_handle<> continuation = nullptr;
+        // Intrusive ref counting - used to destroy continuation in case of cancellation
+        std::atomic<size_t> ref_count = 0;
+      };
+
+      class DataHandle
+      {
+      public:
+        DataHandle(Data& data) : data_(&data)
+        {
+          size_t prev_ref_count = data_->ref_count.fetch_add(1);
+          // This constructor is called when awaiting the result.
+          // We do not allow multiple awaits, thus, this should always be zero.
+          assert(prev_ref_count == 0);
+        }
+
+        DataHandle(const DataHandle& other) : data_(other.data_)
+        {
+          data_->ref_count++;
+        }
+
+        DataHandle& operator=(const DataHandle& other)
+        {
+          decrement_ref_count_();
+          data_ = other.data_;
+          return *this;
+        }
+
+        DataHandle(DataHandle&& other) : data_(other.data_)
+        {
+          data_->ref_count++;
+        }
+
+        DataHandle& operator=(DataHandle&& other)
+        {
+          decrement_ref_count_();
+          data_ = other.data_;
+          return *this;
+        }
+
+        ~DataHandle()
+        {
+          decrement_ref_count_();
+        }
+
+        Data& operator*() const
+        {
+          assert(data_);
+          return *data_;
+        }
+
+        Data* operator->() const
+        {
+          assert(data_);
+          return data_;
+        }
+
+        Data* leak()
+        {
+          assert(data_);
+          return std::exchange(data_, nullptr);
+        }
+
+      private:
+        void decrement_ref_count_()
+        {
+          if (data_ == nullptr)
+          {
+            return;
+          }
+
+          size_t prev_ref_count = data_->ref_count.fetch_sub(1);
+          // This is the last instance - we need to destroy the continuation
+          if (prev_ref_count == 1)
+          {
+            // Copy coroutine handle into the current frame
+            // (`*data_` is stored in the coroutine it will be destroying)
+            auto continuation = data_->continuation;
+            // The continuation may be null if it was reset or not set at all
+            if (continuation != nullptr)
+            {
+              // Destroy the non finished coroutine
+              continuation.destroy();
+            }
+          }
+        }
+
+        Data* data_;
+      };
+
+      Data data_;
+
+      friend class ServiceClientHandler<ServiceType>;
+    };
+
+  } // namespace internal
+
   // --------------------------------------------------------------
   // |                    ServiceClientHandler                    |
   // --------------------------------------------------------------
@@ -74,6 +235,19 @@ namespace mrs_lib
   }
 
   //}
+
+  template <class ServiceType>
+  Task<std::optional<std::shared_ptr<typename ServiceType::Response>>>
+  ServiceClientHandler<ServiceType>::callAwaitable(std::shared_ptr<typename ServiceType::Request> request)
+  {
+    if (!impl_)
+    {
+      RCLCPP_ERROR(rclcpp::get_logger("ServiceClientHandler"), "Not initialized, cannot use callAwaitable()!");
+      co_return std::nullopt;
+    }
+
+    co_return co_await impl_->callAwaitable(request);
+  }
 
   /* getServiceName() //{ */
 
@@ -194,6 +368,11 @@ namespace mrs_lib
         return std::nullopt;
 
       return future;
+    }
+
+    internal::ServiceAwaitable<ServiceType> callAwaitable(const std::shared_ptr<typename ServiceType::Request>& request)
+    {
+      return internal::ServiceAwaitable<ServiceType>(service_client_, request);
     }
 
     /**

--- a/include/mrs_lib/internal/coroutine_callback_helpers.hpp
+++ b/include/mrs_lib/internal/coroutine_callback_helpers.hpp
@@ -1,0 +1,48 @@
+#ifndef MRS_LIB_INTERNAL_COROUTINE_CALLBACK_HELPERS_HPP_
+#define MRS_LIB_INTERNAL_COROUTINE_CALLBACK_HELPERS_HPP_
+
+
+#include <rclcpp/callback_group.hpp>
+
+
+namespace mrs_lib::internal
+{
+
+  /**
+   * @brief Check that callback group type is compatible with coroutine callbacks.
+   *
+   * To simplify the behavior of coroutine callbacks, they currently only
+   * allowed when using reentrant callback group.
+   *
+   * @param callback_group Callback group to check. This can be nullptr.
+   *
+   * @return True if the callback group is coroutine compatible, false otherwise.
+   */
+  inline bool is_callback_group_coro_compatible(const std::shared_ptr<rclcpp::CallbackGroup>& callback_group)
+  {
+    return callback_group->type() == rclcpp::CallbackGroupType::Reentrant;
+  }
+
+  /**
+   * @brief Check that callback group type is compatible with coroutine callbacks. Throws if it is not.
+   *
+   * To simplify the behavior of coroutine callbacks, they currently only
+   * allowed when using reentrant callback group.
+   *
+   * @param callback_group Callback group to check. This can be nullptr.
+   *
+   * @throws std::logic_error if the callback group is not compatible with coroutine callbacks.
+   */
+  inline void require_callback_group_coro_compatible(const std::shared_ptr<rclcpp::CallbackGroup>& callback_group)
+  {
+    if (callback_group == nullptr || callback_group->type() != rclcpp::CallbackGroupType::Reentrant)
+    {
+      std::string msg = "Coroutine callbacks must be used with reentrant callback group.";
+      RCLCPP_ERROR(rclcpp::get_logger("mrs_lib"), "%s", msg.c_str());
+      throw std::logic_error(msg);
+    }
+  }
+
+} // namespace mrs_lib::internal
+
+#endif // MRS_LIB_INTERNAL_COROUTINE_CALLBACK_HELPERS_HPP_

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -10,8 +10,20 @@
 #include <string>
 #include <future>
 
+#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
+#include <mrs_lib/coro/task.hpp>
+
 namespace mrs_lib
 {
+  template <class ServiceType>
+  class ServiceClientHandler;
+
+  namespace internal
+  {
+    template <typename ServiceType>
+      requires(rosidl_generator_traits::is_service<ServiceType>::value)
+    class [[nodiscard("This service call is only performed when `co_await`ed.")]] ServiceAwaitable;
+  }
 
   /* class ServiceClientHandler //{ */
 
@@ -91,6 +103,24 @@ namespace mrs_lib
      * @return Optional shared pointer to the result or std::nullopt if the call failed
      */
     std::optional<std::shared_future<std::shared_ptr<typename ServiceType::Response>>> callAsync(const std::shared_ptr<typename ServiceType::Request>& request);
+
+    /**
+     * @brief Awaitable call of the service.
+     *
+     * This function can be used inside coroutine callbacks (mrs_lib::Task) to
+     * suspend the coroutine until the service completes. The advantage of this
+     * method compared to callSync is that this can run on single threaded
+     * executor - the calling coroutine is suspended and the executor can work
+     * on other tasks. Once the service responds, the calling coroutine is
+     * resumed and the co_await expression returns
+     * `std::optional<std::shared_ptr<Response>>` where `Response` is the
+     * service response type.
+     *
+     * @param request The service request to be sent with the call
+     *
+     * @return Awaitable type that calls the service and returns the result when awaited.
+     */
+    Task<std::optional<std::shared_ptr<typename ServiceType::Response>>> callAwaitable(std::shared_ptr<typename ServiceType::Request> request);
 
     /**
      * @brief Returns the name of the service this client connects to.

--- a/include/mrs_lib/timer_handler.h
+++ b/include/mrs_lib/timer_handler.h
@@ -86,6 +86,39 @@ namespace mrs_lib
   protected:
     MRSTimer() = default;
 
+    /**
+     * @brief Create a callback for coroutine that should only run once at a time.
+     *
+     * Since coroutine callbacks are only allowed for reentrant groups,
+     * the callback could be called while the previous is still in progress.
+     * This helper function creates a callback that is skipped if the previous
+     * one is still running.
+     */
+    template <typename C>
+    static std::function<void()> createNonReentrantCallback(Task<> (C::*method)(), C* instance)
+    {
+      auto is_running = std::make_shared<std::atomic<bool>>(false);
+      return [is_running, method, instance]() -> void {
+        bool was_running = is_running->exchange(true);
+
+        if (!was_running)
+        {
+          // The callback was not running and we have set it as running, we start it here.
+          start_task(
+              // Capturing lambdas should not be used as coroutines.
+              // Pass the values as arguments instead.
+              [](std::shared_ptr<std::atomic<bool>> is_running, Task<> (C::*method)(), C* instance) -> mrs_lib::Task<> {
+                // Run the user specified callback.
+                co_await std::invoke(method, instance);
+                // The task finished so we store false to allow another callback to start.
+                is_running->store(false);
+                co_return;
+              },
+              is_running, method, instance);
+        }
+      };
+    }
+
     rclcpp::Node::SharedPtr node_;
   };
 
@@ -105,16 +138,34 @@ namespace mrs_lib
 
     ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, const std::function<void()>& callback);
 
+    /**
+     * @brief Create Ros timer with coroutine callback.
+     *
+     * Using coroutine callbacks is only allowed with reentrant callback group.
+     * If the specified callback group is not reentrant, this throws an exception.
+     *
+     * To make the callback design simpler, the coroutine itself will not run
+     * again until the previous one completely finished.
+     */
     template <typename C>
     ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), C* instance)
-        : ROSTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+        : ROSTimer(opts, rate, createNonReentrantCallback(method, instance))
     {
       internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
     }
 
+    /**
+     * @brief Create Ros timer with coroutine callback.
+     *
+     * Using coroutine callbacks is only allowed with reentrant callback group.
+     * If the specified callback group is not reentrant, this throws an exception.
+     *
+     * To make the callback design simpler, the coroutine itself will not run
+     * again until the previous one completely finished.
+     */
     template <typename C>
     ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), std::shared_ptr<C> instance)
-        : ROSTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+        : ROSTimer(opts, rate, createNonReentrantCallback(method, instance))
     {
       internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
     }
@@ -195,16 +246,34 @@ namespace mrs_lib
 
     ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, const std::function<void()>& callback);
 
+    /**
+     * @brief Create thread timer with coroutine callback.
+     *
+     * Using coroutine callbacks is only allowed with reentrant callback group.
+     * If the specified callback group is not reentrant, this throws an exception.
+     *
+     * To make the callback design simpler, the coroutine itself will not run
+     * again until the previous one completely finished.
+     */
     template <typename C>
     ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), C* instance)
-        : ThreadTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+        : ThreadTimer(opts, rate, createNonReentrantCallback(method, instance))
     {
       internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
     }
 
+    /**
+     * @brief Create thread timer with coroutine callback.
+     *
+     * Using coroutine callbacks is only allowed with reentrant callback group.
+     * If the specified callback group is not reentrant, this throws an exception.
+     *
+     * To make the callback design simpler, the coroutine itself will not run
+     * again until the previous one completely finished.
+     */
     template <typename C>
     ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), std::shared_ptr<C> instance)
-        : ThreadTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+        : ThreadTimer(opts, rate, createNonReentrantCallback(method, instance))
     {
       internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
     }

--- a/include/mrs_lib/timer_handler.h
+++ b/include/mrs_lib/timer_handler.h
@@ -4,6 +4,9 @@
 #include <rclcpp/rclcpp.hpp>
 #include <mutex>
 
+#include <mrs_lib/coro/runners.hpp>
+#include <mrs_lib/coro/task.hpp>
+#include <mrs_lib/internal/coroutine_callback_helpers.hpp>
 #include <mrs_lib/utils.h>
 
 namespace mrs_lib
@@ -102,6 +105,20 @@ namespace mrs_lib
 
     ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, const std::function<void()>& callback);
 
+    template <typename C>
+    ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), C* instance)
+        : ROSTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+    {
+      internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
+    }
+
+    template <typename C>
+    ROSTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), std::shared_ptr<C> instance)
+        : ROSTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+    {
+      internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
+    }
+
     /**
      * @brief stop the timer
      */
@@ -177,6 +194,20 @@ namespace mrs_lib
     ThreadTimer(const rclcpp::Node::SharedPtr& node, const rclcpp::Rate& rate, const std::function<void()>& callback);
 
     ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, const std::function<void()>& callback);
+
+    template <typename C>
+    ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), C* instance)
+        : ThreadTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+    {
+      internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
+    }
+
+    template <typename C>
+    ThreadTimer(const mrs_lib::TimerHandlerOptions& opts, const rclcpp::Rate& rate, Task<> (C::*method)(), std::shared_ptr<C> instance)
+        : ThreadTimer(opts, rate, [method, instance]() -> void { start_task(method, instance); })
+    {
+      internal::require_callback_group_coro_compatible(opts.callback_group.value_or(nullptr));
+    }
 
     /**
      * @brief stop the timer

--- a/src/coro/internal/thread_local_continuation_scheduler.cpp
+++ b/src/coro/internal/thread_local_continuation_scheduler.cpp
@@ -1,0 +1,88 @@
+#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
+
+#include <cassert>
+#include <coroutine>
+#include <cstddef>
+
+namespace mrs_lib::internal
+{
+
+  namespace
+  {
+
+    // This is a workaround to GCC generated code overflowing stack when using symmetric transfer
+    class ThreadLocalContinuationScheduler
+    {
+    public:
+      static void resume_coroutine(std::coroutine_handle<> handle)
+      {
+        auto&& scheduler = get_thread_local_scheduler_();
+        scheduler.run_until_suspend_(handle);
+      }
+
+      static void schedule_coroutine_continuation(std::coroutine_handle<> handle)
+      {
+        auto&& scheduler = get_thread_local_scheduler_();
+        scheduler.set_continuation_(handle);
+      }
+
+      ~ThreadLocalContinuationScheduler() = default;
+      ThreadLocalContinuationScheduler(const ThreadLocalContinuationScheduler&) = delete;
+      ThreadLocalContinuationScheduler& operator=(const ThreadLocalContinuationScheduler&) = delete;
+      ThreadLocalContinuationScheduler(ThreadLocalContinuationScheduler&&) = delete;
+      ThreadLocalContinuationScheduler& operator=(ThreadLocalContinuationScheduler&&) = delete;
+
+    private:
+      static ThreadLocalContinuationScheduler& get_thread_local_scheduler_()
+      {
+        thread_local static ThreadLocalContinuationScheduler scheduler;
+        return scheduler;
+      }
+
+      ThreadLocalContinuationScheduler() = default;
+
+      void set_continuation_(std::coroutine_handle<> continuation)
+      {
+        assert(running);
+        assert(released_id_ == stored_id_);
+        continuation_ = continuation;
+        stored_id_++;
+      }
+
+      void run_until_suspend_(std::coroutine_handle<> handle)
+      {
+        assert(!running);
+        running = true;
+        set_continuation_(handle);
+        assert(released_id_ + 1 == stored_id_);
+        while (released_id_ != stored_id_)
+        {
+          assert(released_id_ + 1 == stored_id_);
+          released_id_++;
+          continuation_.resume();
+        }
+        assert(running);
+        running = false;
+      }
+
+      // Using unsigned ids that have defined overflow, removing the need to manually handle.
+      size_t stored_id_ = 0;
+      size_t released_id_ = 0;
+      bool running = false;
+      std::coroutine_handle<> continuation_;
+    };
+
+  } // namespace
+
+  void resume_coroutine(std::coroutine_handle<> handle)
+  {
+    ThreadLocalContinuationScheduler::resume_coroutine(handle);
+  }
+
+  void schedule_coroutine_continuation(std::coroutine_handle<> handle)
+  {
+    ThreadLocalContinuationScheduler::schedule_coroutine_continuation(handle);
+  }
+
+
+} // namespace mrs_lib::internal

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -9,6 +9,7 @@ endfunction()
 
 add_subdirectory(attitude_converter)
 add_subdirectory(batch_visualizer)
+add_subdirectory(coro)
 add_subdirectory(dynparam_mgr)
 add_subdirectory(geometry)
 add_subdirectory(lkf)

--- a/test/coro/CMakeLists.txt
+++ b/test/coro/CMakeLists.txt
@@ -1,0 +1,10 @@
+get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
+
+ament_add_gtest(test_${TEST_NAME}
+  test.cpp
+  TIMEOUT 120
+)
+
+target_link_libraries(test_${TEST_NAME}
+  mrs_lib::mrs_lib
+)

--- a/test/coro/test.cpp
+++ b/test/coro/test.cpp
@@ -1,0 +1,563 @@
+#include <format>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <mrs_lib/coro/runners.hpp>
+#include <mrs_lib/coro/task.hpp>
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+//// Static assert tests                                                    ////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+  struct PotentiallyThrowingMoveOnly
+  {
+    ~PotentiallyThrowingMoveOnly() = default;
+    PotentiallyThrowingMoveOnly(const PotentiallyThrowingMoveOnly&) = delete;
+    PotentiallyThrowingMoveOnly& operator=(const PotentiallyThrowingMoveOnly&) = delete;
+    PotentiallyThrowingMoveOnly(PotentiallyThrowingMoveOnly&&) noexcept(false)
+    {
+      throw std::logic_error("");
+    };
+    PotentiallyThrowingMoveOnly& operator=(PotentiallyThrowingMoveOnly&&) noexcept(false)
+    {
+      throw std::logic_error("");
+    };
+  };
+
+  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<int>>().set_value(10)),
+                "ResultStorage::set_value should be noexcept when stored type is noexcept move constructible");
+  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<std::string>>().set_value(std::declval<std::string>())),
+                "ResultStorage::set_value should be noexcept when stored type is noexcept move constructible");
+  static_assert(!noexcept(std::declval<mrs_lib::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_value(std::declval<PotentiallyThrowingMoveOnly>())),
+                "ResultStorage::set_value should NOT be noexcept when stored type is NOT noexcept move constructible");
+
+  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<int>>().set_exception(std::declval<std::exception_ptr>())),
+                "ResultStorage::set_exception should be noexcept");
+  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<std::string>>().set_exception(std::declval<std::exception_ptr>())),
+                "ResultStorage::set_exception should be noexcept");
+  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_exception(std::declval<std::exception_ptr>())),
+                "ResultStorage::set_exception should be noexcept");
+
+  consteval bool result_storage_test_default_ctor_dtor()
+  {
+    mrs_lib::internal::ResultStorage<int> storage;
+
+    return true;
+  }
+  static_assert(result_storage_test_default_ctor_dtor());
+
+  consteval bool result_storage_test_int()
+  {
+    mrs_lib::internal::ResultStorage<int> storage;
+    storage.set_value(10);
+    assert(std::move(storage).get_value() == 10);
+
+    return true;
+  }
+  static_assert(result_storage_test_int());
+
+  consteval bool result_storage_test_string()
+  {
+    std::string s = "asdf";
+    mrs_lib::internal::ResultStorage<std::string> storage;
+    storage.set_value(std::move(s));
+    assert(std::move(storage).get_value() == "asdf");
+
+    return true;
+  }
+  static_assert(result_storage_test_string());
+
+} // namespace
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+//// Runtime tests                                                          ////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+
+namespace
+{
+  //////////////////////////////////////////////////////////////////////////////
+  // MrsLibCoro                                                               //
+  //////////////////////////////////////////////////////////////////////////////
+
+  constexpr std::string_view test_exception_message = "Expected test exception";
+  constexpr std::string_view test_not_thrown_exception_message = "This should not be thrown";
+
+  [[noreturn]] void throw_expected_exception()
+  {
+    throw std::logic_error(std::string(test_exception_message));
+  }
+
+  mrs_lib::Task<> co_takes_val(int)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_takes_lval_ref(int&)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_takes_rval_ref(int&&)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_takes_move_only(std::unique_ptr<int>)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_takes_move_only_lval_ref(std::unique_ptr<int>&)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_takes_move_only_rval_ref(std::unique_ptr<int>&&)
+  {
+    co_return;
+  };
+
+  mrs_lib::Task<> co_set_42(int& out)
+  {
+    out = 42;
+    co_return;
+  }
+
+  mrs_lib::Task<int> co_42()
+  {
+    co_return 42;
+  }
+
+  mrs_lib::Task<std::unique_ptr<int>> co_uptr_42()
+  {
+    auto val = std::make_unique<int>(42);
+    co_return val;
+  }
+
+  mrs_lib::Task<int> co_2_times_42()
+  {
+    auto a = co_await co_42();
+    auto b = co_await co_uptr_42();
+    co_return a + (*b);
+  }
+
+  mrs_lib::Task<> co_throws_logic_error()
+  {
+    throw_expected_exception();
+    co_return;
+  }
+
+  mrs_lib::Task<> co_call_throwning(size_t levels)
+  {
+    if (levels == 0)
+    {
+      co_await co_throws_logic_error();
+    } else
+    {
+      co_await co_call_throwning(levels - 1);
+    }
+  }
+
+  mrs_lib::Task<int> co_throws_logic_error_non_void()
+  {
+    throw_expected_exception();
+    co_return 42;
+  }
+
+  mrs_lib::Task<int> co_call_throwning_non_void(size_t levels)
+  {
+    if (levels == 0)
+    {
+      co_return co_await co_throws_logic_error_non_void();
+    } else
+    {
+      co_return co_await co_call_throwning_non_void(levels - 1);
+    }
+  }
+
+  template <typename R, typename... FuncArgs, typename... Args>
+    requires std::invocable<mrs_lib::Task<R> (*)(FuncArgs...), Args...>
+  mrs_lib::Task<bool> co_check_throws(mrs_lib::Task<R> (*coroutine)(FuncArgs...), Args&&... args)
+  {
+    bool expected_error = false;
+    try
+    {
+      co_await coroutine(std::forward<Args>(args)...);
+    }
+    catch (std::logic_error& e)
+    {
+      expected_error = e.what() == test_exception_message;
+      if (!expected_error)
+      {
+        std::cout << "Expected error msg: '" << test_exception_message << "'\n";
+        std::cout << "Observed error msg: '" << e.what() << "'\n";
+      }
+    }
+    co_return expected_error;
+  }
+
+  struct ErrorOnMove
+  {
+    ErrorOnMove() = default;
+    ErrorOnMove(const ErrorOnMove&) = delete;
+    ErrorOnMove& operator=(const ErrorOnMove&) = delete;
+    ErrorOnMove(ErrorOnMove&&) noexcept(false)
+    {
+      throw_expected_exception();
+    }
+    ErrorOnMove& operator=(ErrorOnMove&&) noexcept(false)
+    {
+      throw_expected_exception();
+    }
+  };
+
+  mrs_lib::Task<ErrorOnMove> co_get_error_on_move()
+  {
+    co_return ErrorOnMove{};
+  }
+
+
+  mrs_lib::Task<std::exception_ptr> co_get_exception_ptr()
+  {
+    co_return std::make_exception_ptr(std::logic_error(std::string(test_not_thrown_exception_message)));
+  }
+
+  mrs_lib::Task<bool> check_get_exception_ptr()
+  {
+    std::exception_ptr eptr = nullptr;
+    try
+    {
+      eptr = co_await co_get_exception_ptr();
+    }
+    catch (std::exception& e)
+    {
+      std::cout << std::format("This should not throw. Caught exception: \n", e.what());
+    }
+
+    if (eptr == nullptr)
+    {
+      std::cout << "Error: exception_ptr is empty!\n";
+      co_return false;
+    }
+
+    bool success = false;
+
+    try
+    {
+      std::rethrow_exception(eptr);
+    }
+    catch (std::logic_error& e)
+    {
+      success = e.what() == test_not_thrown_exception_message;
+    }
+
+    co_return success;
+  }
+
+  TEST(MrsLibCoro, StartTaskArgsValueCategories)
+  {
+    // This test checks that start task compiles with all of these signatures.
+
+    int lval_int = 42;
+    std::unique_ptr<int> lval_uptr = std::make_unique<int>(42);
+    // function reference
+    mrs_lib::start_task(co_takes_val, 42);
+    mrs_lib::start_task(co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::start_task(co_takes_rval_ref, 42);
+    mrs_lib::start_task(co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::start_task(co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::start_task(co_takes_move_only_rval_ref, std::make_unique<int>(42));
+    // function pointer
+    mrs_lib::start_task(&co_takes_val, 42);
+    mrs_lib::start_task(&co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::start_task(&co_takes_rval_ref, 42);
+    mrs_lib::start_task(&co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::start_task(&co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::start_task(&co_takes_move_only_rval_ref, std::make_unique<int>(42));
+  }
+
+  TEST(MrsLibCoro, StartCopyDecays)
+  {
+    struct Func
+    {
+      mrs_lib::Task<> operator()(int&& arg)
+      {
+        arg = 24;
+        co_return;
+      }
+      mrs_lib::Task<> operator()(int& arg)
+      {
+        arg = 42;
+        co_return;
+      }
+    };
+
+    int val = 0;
+
+    // This call should copy the value and invoke the `int &&` overload
+    mrs_lib::start_task(Func{}, val);
+
+    EXPECT_EQ(val, 0);
+
+    // The reference wrapper should be able to keep the reference and call the `int&` overload
+    mrs_lib::start_task(Func{}, std::ref(val));
+
+    EXPECT_EQ(val, 42);
+  }
+
+  TEST(MrsLibCoro, StartTaskLambda)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, StartTaskFuncRef)
+  {
+    int result = 0;
+
+    // No ampersand in front of function name - passing function reference
+    mrs_lib::start_task(co_set_42, std::ref(result));
+
+    EXPECT_EQ(result, 42);
+  }
+
+  TEST(MrsLibCoro, StartTaskFuncPtr)
+  {
+    int result = 0;
+
+    // Ampersand in front of function name - passing function pointer
+    mrs_lib::start_task(&co_set_42, std::ref(result));
+
+    EXPECT_EQ(result, 42);
+  }
+
+  TEST(MrsLibCoro, CoroIsLazy)
+  {
+    int result = 0;
+
+    // The function is called but not co-awaited. Since the task is lazy, the
+    // value in result should not be changed by this.
+    [[maybe_unused]] auto task = co_set_42(result);
+
+    EXPECT_EQ(result, 0);
+  }
+
+
+  TEST(MrsLibCoro, ReturnInt)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          int val = co_await co_42();
+          EXPECT_EQ(val, 42);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, ReturnUniquePtr)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          std::unique_ptr<int> val = co_await co_uptr_42();
+          EXPECT_EQ(*val, 42);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, ChainedCoroutines)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          int val = co_await co_2_times_42();
+          EXPECT_EQ(val, 84);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, ExceptionPropagationVoid)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          bool val = co_await co_check_throws(co_throws_logic_error);
+          EXPECT_TRUE(val);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, MultiLevelExceptionPropagationVoid)
+  {
+    for (size_t level = 1; level < 10; level++)
+    {
+      bool finished = false;
+
+      mrs_lib::start_task(
+          [](bool& finished, size_t level) -> mrs_lib::Task<> {
+            bool val = co_await co_check_throws(co_call_throwning, level);
+            EXPECT_TRUE(val);
+            finished = true;
+            co_return;
+          },
+          std::ref(finished), level);
+
+      EXPECT_TRUE(finished);
+    }
+  }
+
+  TEST(MrsLibCoro, ExceptionPropagationNonVoid)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          bool val = co_await co_check_throws(co_throws_logic_error_non_void);
+          EXPECT_TRUE(val);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, MultiLevelExceptionPropagationNonVoid)
+  {
+    for (size_t level = 1; level < 10; level++)
+    {
+      bool finished = false;
+
+      mrs_lib::start_task(
+          [](bool& finished, size_t level) -> mrs_lib::Task<> {
+            bool val = co_await co_check_throws(co_call_throwning_non_void, level);
+            EXPECT_TRUE(val);
+            finished = true;
+            co_return;
+          },
+          std::ref(finished), level);
+
+      EXPECT_TRUE(finished);
+    }
+  }
+
+  TEST(MrsLibCoro, ErrorOnReturn)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          bool val = co_await co_check_throws(co_get_error_on_move);
+          EXPECT_TRUE(val);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, ReturnExceptionPtr)
+  {
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          bool val = co_await check_get_exception_ptr();
+          EXPECT_TRUE(val);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+
+  //////////////////////////////////////////////////////////////////////////////
+  // MrsLibCoroLoops                                                          //
+  //////////////////////////////////////////////////////////////////////////////
+
+  class MrsLibCoroLoops : public ::testing::TestWithParam<size_t>
+  {
+  };
+
+  mrs_lib::Task<size_t> co_get_1()
+  {
+    co_return 1;
+  }
+
+  const volatile auto get_one_coro_ptr = &co_get_1;
+
+  mrs_lib::Task<size_t> co_test_long_loop(size_t iterations)
+  {
+    size_t sum = 0;
+    for (size_t i = 0; i < iterations; ++i)
+    {
+      // Using volatile function pointer to remove some optimizations
+      sum += co_await (*get_one_coro_ptr)();
+    }
+    co_return sum;
+  }
+
+  // This test checks that long chains of synchronous completions work correctly.
+  // On incorrect implementations, long chains of synchronous completions may
+  // cause stack overflow. Thus, this test runs long loops of synchronously
+  // completing tasks to check for this stack overflow.
+  TEST_P(MrsLibCoroLoops, LongLoop)
+  {
+    const size_t iterations = GetParam();
+
+    bool finished = false;
+
+    mrs_lib::start_task(
+        [](bool& finished, size_t iterations) -> mrs_lib::Task<> {
+          size_t val = co_await co_test_long_loop(iterations);
+          EXPECT_EQ(val, iterations);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished), iterations);
+
+    EXPECT_TRUE(finished);
+  }
+
+  INSTANTIATE_TEST_SUITE_P(I, MrsLibCoroLoops, ::testing::Values(1'000, 10'000, 100'000, 1'000'000, 10'000'000, 100'000'000),
+                           [](const testing::TestParamInfo<MrsLibCoroLoops::ParamType>& info) { return std::format("{}_iters", info.param); });
+
+} // namespace

--- a/test/service_client_handler/test.cpp
+++ b/test/service_client_handler/test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <mrs_lib/coro/runners.hpp>
 #include <mrs_lib/service_client_handler.h>
 
 #include <std_srvs/srv/set_bool.hpp>
@@ -37,12 +38,13 @@ protected:
 
   /* initialize() //{ */
 
+  template <typename ExecutorType = rclcpp::executors::MultiThreadedExecutor>
   void initialize(const rclcpp::NodeOptions& node_options = rclcpp::NodeOptions())
   {
 
     node_ = std::make_shared<rclcpp::Node>("test_service_client_handler", node_options);
 
-    executor_ = std::make_shared<rclcpp::executors::MultiThreadedExecutor>();
+    executor_ = std::make_shared<ExecutorType>();
     executor_->add_node(node_);
   }
 
@@ -227,6 +229,76 @@ TEST_F(Test, asynctest_call)
 }
 
 //}
+
+mrs_lib::Task<std::optional<std::shared_ptr<typename std_srvs::srv::SetBool::Response>>>
+call_indirect(mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>& client, std::shared_ptr<std_srvs::srv::SetBool::Request> request, size_t depth)
+{
+  if (depth == 0)
+  {
+    co_return co_await client.callAwaitable(request);
+  } else
+  {
+    co_return co_await call_indirect(client, std::move(request), depth - 1);
+  }
+}
+
+
+TEST_F(Test, CoroCall)
+{
+  // Coroutine based callbacks should handle waiting on single threaded executor
+  initialize<rclcpp::executors::SingleThreadedExecutor>(rclcpp::NodeOptions().use_intra_process_comms(false));
+
+  auto clock = node_->get_clock();
+
+  // | ----------------- create a service server ---------------- |
+
+  const auto callback_group_ = node_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  const auto service_server = node_->create_service<std_srvs::srv::SetBool>(
+      "/service1", std::bind(&Test::callbackService, this, std::placeholders::_1, std::placeholders::_2), rclcpp::ServicesQoS(), callback_group_);
+
+  // | ----------------- create a service client ---------------- |
+
+  mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool> client1 = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node_, "service1");
+
+  RCLCPP_INFO(node_->get_logger(), "initialized");
+
+  std::atomic<bool> completed = false;
+  rclcpp::TimerBase::SharedPtr tim;
+
+  const auto test_fun = [&]() -> mrs_lib::Task<> {
+    tim->cancel(); // just a one-shot timer
+
+    auto request = std::make_shared<std_srvs::srv::SetBool::Request>();
+
+    {
+      request->data = true;
+
+      auto opt_response = co_await call_indirect(client1, request, 5);
+
+      EXPECT_TRUE(opt_response.has_value());
+      if (!opt_response.has_value())
+      {
+        co_return;
+      }
+
+      auto response = opt_response.value();
+
+      EXPECT_TRUE(response);
+      EXPECT_TRUE(response->success);
+      EXPECT_EQ(response->message, "set");
+    }
+
+    RCLCPP_INFO(node_->get_logger(), "finished");
+
+    completed = true;
+    despin();
+  };
+
+  tim = node_->create_timer(0s, [test_fun]() -> void { mrs_lib::start_task(test_fun); }, callback_group_);
+  executor_->spin();
+
+  ASSERT_TRUE(completed);
+}
 
 /* TEST_F(Test, test_bad_address) //{ */
 


### PR DESCRIPTION
# Description
This PR adds C++20 coroutines support. It contains the following parts:
- Coroutine library support (task type, awaiting, ...)
- Awaitable service calls to `ServiceClientHandler`
- Support for adding coroutine based callback to timers (both `ROSTimer` and `ThreadTimer`)

## `mrs_lib::Task<T>`
This is the task type that is returned by coroutines. It is immovable to force immediate awaiting.

The task does not use symmetric transfer to schedule continuations because there is currently unfixed bug in gcc that can cause stack overflows (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100897). To overcome this issue, the continuations are scheduled by a simple thread-local scheduler.

## Awaitable services
`ServiceClientHandler` got a new method called `callAwaitable`. This returns object that can be `co_await`ed by the calling coroutine to call the service and suspend. After the service is completed, the coroutine is woken up to continue its execution.

## Coroutine callbacks for timers
This patch adds support for creating coroutine callbacks only in timers, other callbacks will be added in the future. The constructor for creating these callbacks currently allows only methods taking no arguments and binds the `this` pointer internally - either form raw pointer or shared pointer.
