### PR TITLE
Move start_task to internal namespace

### DIFF
--- a/include/mrs_lib/coro/runners.hpp
+++ b/include/mrs_lib/coro/runners.hpp
@@ -67,25 +67,25 @@ namespace mrs_lib
       co_await std::invoke(decay_copy(std::forward<F>(task)), decay_copy(std::forward<Args>(args))...);
     }
 
-  } // namespace internal
+    /**
+     * @brief Start execution of a task from outside of a coroutine.
+     *
+     * This function starts the execution of the coroutine using the provided
+     * arguments. The passed arguments are decay-copied into the coroutine frame
+     * (similarly to std::thread).
+     *
+     * Using this function from user code is not usually necessary. It can be
+     * avoided by `co_await`ing the tasks and using callbacks that support passing
+     * coroutine callbacks.
+     */
+    template <typename F, typename... Args>
+      requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
+    void start_task(F&& task, Args&&... args)
+    {
+      internal::start_task_impl(std::forward<F>(task), std::forward<Args>(args)...);
+    }
 
-  /**
-   * @brief Start execution of a task from outside of a coroutine.
-   *
-   * This function starts the execution of the coroutine using the provided
-   * arguments. The passed arguments are decay-copied into the coroutine frame
-   * (similarly to std::thread).
-   *
-   * Using this function from user code is not usually necessary. It can be
-   * avoided by `co_await`ing the tasks and using callbacks that support passing
-   * coroutine callbacks.
-   */
-  template <typename F, typename... Args>
-    requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
-  void start_task(F&& task, Args&&... args)
-  {
-    internal::start_task_impl(std::forward<F>(task), std::forward<Args>(args)...);
-  }
+  } // namespace internal
 
 } // namespace mrs_lib
 

--- a/include/mrs_lib/timer_handler.h
+++ b/include/mrs_lib/timer_handler.h
@@ -104,7 +104,7 @@ namespace mrs_lib
         if (!was_running)
         {
           // The callback was not running and we have set it as running, we start it here.
-          start_task(
+          internal::start_task(
               // Capturing lambdas should not be used as coroutines.
               // Pass the values as arguments instead.
               [](std::shared_ptr<std::atomic<bool>> is_running, Task<> (C::*method)(), C* instance) -> mrs_lib::Task<> {

--- a/test/coro/test.cpp
+++ b/test/coro/test.cpp
@@ -268,19 +268,19 @@ namespace
     int lval_int = 42;
     std::unique_ptr<int> lval_uptr = std::make_unique<int>(42);
     // function reference
-    mrs_lib::start_task(co_takes_val, 42);
-    mrs_lib::start_task(co_takes_lval_ref, std::ref(lval_int));
-    mrs_lib::start_task(co_takes_rval_ref, 42);
-    mrs_lib::start_task(co_takes_move_only, std::make_unique<int>(42));
-    mrs_lib::start_task(co_takes_move_only_lval_ref, std::ref(lval_uptr));
-    mrs_lib::start_task(co_takes_move_only_rval_ref, std::make_unique<int>(42));
+    mrs_lib::internal::start_task(co_takes_val, 42);
+    mrs_lib::internal::start_task(co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::internal::start_task(co_takes_rval_ref, 42);
+    mrs_lib::internal::start_task(co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::internal::start_task(co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::internal::start_task(co_takes_move_only_rval_ref, std::make_unique<int>(42));
     // function pointer
-    mrs_lib::start_task(&co_takes_val, 42);
-    mrs_lib::start_task(&co_takes_lval_ref, std::ref(lval_int));
-    mrs_lib::start_task(&co_takes_rval_ref, 42);
-    mrs_lib::start_task(&co_takes_move_only, std::make_unique<int>(42));
-    mrs_lib::start_task(&co_takes_move_only_lval_ref, std::ref(lval_uptr));
-    mrs_lib::start_task(&co_takes_move_only_rval_ref, std::make_unique<int>(42));
+    mrs_lib::internal::start_task(&co_takes_val, 42);
+    mrs_lib::internal::start_task(&co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::internal::start_task(&co_takes_rval_ref, 42);
+    mrs_lib::internal::start_task(&co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::internal::start_task(&co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::internal::start_task(&co_takes_move_only_rval_ref, std::make_unique<int>(42));
   }
 
   TEST(MrsLibCoro, StartCopyDecays)
@@ -302,12 +302,12 @@ namespace
     int val = 0;
 
     // This call should copy the value and invoke the `int &&` overload
-    mrs_lib::start_task(Func{}, val);
+    mrs_lib::internal::start_task(Func{}, val);
 
     EXPECT_EQ(val, 0);
 
     // The reference wrapper should be able to keep the reference and call the `int&` overload
-    mrs_lib::start_task(Func{}, std::ref(val));
+    mrs_lib::internal::start_task(Func{}, std::ref(val));
 
     EXPECT_EQ(val, 42);
   }
@@ -316,7 +316,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           finished = true;
           co_return;
@@ -331,7 +331,7 @@ namespace
     int result = 0;
 
     // No ampersand in front of function name - passing function reference
-    mrs_lib::start_task(co_set_42, std::ref(result));
+    mrs_lib::internal::start_task(co_set_42, std::ref(result));
 
     EXPECT_EQ(result, 42);
   }
@@ -341,7 +341,7 @@ namespace
     int result = 0;
 
     // Ampersand in front of function name - passing function pointer
-    mrs_lib::start_task(&co_set_42, std::ref(result));
+    mrs_lib::internal::start_task(&co_set_42, std::ref(result));
 
     EXPECT_EQ(result, 42);
   }
@@ -362,7 +362,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_42();
           EXPECT_EQ(val, 42);
@@ -378,7 +378,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           std::unique_ptr<int> val = co_await co_uptr_42();
           EXPECT_EQ(*val, 42);
@@ -394,7 +394,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_2_times_42();
           EXPECT_EQ(val, 84);
@@ -410,7 +410,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_throws_logic_error);
           EXPECT_TRUE(val);
@@ -428,7 +428,7 @@ namespace
     {
       bool finished = false;
 
-      mrs_lib::start_task(
+      mrs_lib::internal::start_task(
           [](bool& finished, size_t level) -> mrs_lib::Task<> {
             bool val = co_await co_check_throws(co_call_throwning, level);
             EXPECT_TRUE(val);
@@ -445,7 +445,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_throws_logic_error_non_void);
           EXPECT_TRUE(val);
@@ -463,7 +463,7 @@ namespace
     {
       bool finished = false;
 
-      mrs_lib::start_task(
+      mrs_lib::internal::start_task(
           [](bool& finished, size_t level) -> mrs_lib::Task<> {
             bool val = co_await co_check_throws(co_call_throwning_non_void, level);
             EXPECT_TRUE(val);
@@ -480,7 +480,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_get_error_on_move);
           EXPECT_TRUE(val);
@@ -496,7 +496,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await check_get_exception_ptr();
           EXPECT_TRUE(val);
@@ -545,7 +545,7 @@ namespace
 
     bool finished = false;
 
-    mrs_lib::start_task(
+    mrs_lib::internal::start_task(
         [](bool& finished, size_t iterations) -> mrs_lib::Task<> {
           size_t val = co_await co_test_long_loop(iterations);
           EXPECT_EQ(val, iterations);

--- a/test/service_client_handler/test.cpp
+++ b/test/service_client_handler/test.cpp
@@ -294,7 +294,7 @@ TEST_F(Test, CoroCall)
     despin();
   };
 
-  tim = node_->create_timer(0s, [test_fun]() -> void { mrs_lib::start_task(test_fun); }, callback_group_);
+  tim = node_->create_timer(0s, [test_fun]() -> void { mrs_lib::internal::start_task(test_fun); }, callback_group_);
   executor_->spin();
 
   ASSERT_TRUE(completed);


### PR DESCRIPTION
The start_task is likely not needed by users of the library and hiding it may simplify future development.