### PR TITLE
add unique_ptr overload to PublisherHandler for zero-copy IPC

### DIFF
--- a/include/mrs_lib/impl/publisher_handler.hpp
+++ b/include/mrs_lib/impl/publisher_handler.hpp
@@ -156,6 +156,40 @@ namespace mrs_lib
 
   //}
 
+  /* publish(std::unique_ptr<TopicType> msg) //{ */
+
+  template <class TopicType>
+  void PublisherHandler_impl<TopicType>::publish(std::unique_ptr<TopicType> msg)
+  {
+    if (!publisher_initialized_)
+    {
+      return;
+    }
+
+    {
+      std::scoped_lock lock(mutex_publisher_);
+
+      rclcpp::Time now = node_->get_clock()->now();
+
+      if (throttle_min_dt_ > 0)
+      {
+
+        double passed = (now - last_time_published_).seconds();
+
+        if (passed < throttle_min_dt_)
+        {
+          return;
+        }
+      }
+
+      publisher_->publish(std::move(msg));
+
+      last_time_published_ = now;
+    }
+  }
+
+  //}
+
   /* getNumSubscribers(void) //{ */
 
   template <class TopicType>
@@ -258,6 +292,7 @@ namespace mrs_lib
 
   //}
 
+
   /* /1* publish(const std::shared_ptr<TopicType const>& msg) //{ *1/ */
 
   /* template <class TopicType> */
@@ -275,6 +310,18 @@ namespace mrs_lib
   {
 
     impl_->publish(msg);
+  }
+
+  //}
+
+
+  /* publish(std::unique_ptr<TopicType> msg) //{ */
+
+  template <class TopicType>
+  void PublisherHandler<TopicType>::publish(std::unique_ptr<TopicType> msg)
+  {
+
+    impl_->publish(std::move(msg));
   }
 
   //}

--- a/include/mrs_lib/publisher_handler.h
+++ b/include/mrs_lib/publisher_handler.h
@@ -95,6 +95,13 @@ namespace mrs_lib
     void publish(typename TopicType::ConstSharedPtr msg);
 
     /**
+     * @brief publish message, unique_ptr overload
+     *
+     * @param msg message
+     */
+    void publish(std::unique_ptr<TopicType> msg);
+
+    /**
      * @brief get number of subscribers
      *
      * @return the number of subscribers
@@ -199,6 +206,13 @@ namespace mrs_lib
      * @param msg
      */
     void publish(typename TopicType::ConstSharedPtr msg);
+
+    /**
+     * @brief publish message, unique_ptr overload
+     *
+     * @param msg message
+     */
+    void publish(std::unique_ptr<TopicType> msg);
 
     /**
      * @brief get number of subscribers


### PR DESCRIPTION
ROS 2 intra-process communication only achieves zero-copy when the message is published as `std::unique_ptr<T>`, since this is the only case where the `rclcpp IntraProcessManager` can transfer ownership without copying. PublisherHandler previously exposed only the `const T&`, `shared_ptr<T>` and `ConstSharedPtr` overloads, all of which fall back to a copy in the intra-process path.

Add a `publish(std::unique_ptr<TopicType>)` overload to both `PublisherHandler` and `PublisherHandler_impl` that forwards ownership all the way down to` rclcpp::Publisher::publish` via `std::move`. Throttle and initialization checks behave identically to the other overloads.