### PR TITLE
Add workaround for symmetric transfer bug to `mrs_lib::Task`

### DIFF
--- a/include/mrs_lib/attitude_converter.h
+++ b/include/mrs_lib/attitude_converter.h
@@ -90,7 +90,7 @@ namespace mrs_lib
      *
      * @param vector3
      */
-    Vector3Converter(const tf2::Vector3& vector3) : vector3_(vector3) {};
+    Vector3Converter(const tf2::Vector3& vector3) : vector3_(vector3){};
 
     /**
      * @brief Constructor with Eigen::Vector3

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -97,6 +97,7 @@ namespace mrs_lib
 
         // SYMMETRIC TRANSFER IS BROKEN IN GCC and can result in stack
         // overflow when many tasks complete synchronously.
+        // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100897
         // Because of this problem, the `await_suspend` uses the void signature
         // and resumes the continuation on a thread-local scheduler as a workaround.
         void await_suspend(std::coroutine_handle<Derived> task_handle) noexcept;
@@ -250,10 +251,15 @@ namespace mrs_lib
         return false;
       }
 
-      std::coroutine_handle<> await_suspend(std::coroutine_handle<> continuation)
+      // SYMMETRIC TRANSFER IS BROKEN IN GCC and can result in stack
+      // overflow when many tasks complete synchronously.
+      // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100897
+      // Because of this problem, the `await_suspend` uses the void signature
+      // and resumes the continuation on a thread-local scheduler as a workaround.
+      void await_suspend(std::coroutine_handle<> continuation)
       {
         task_handle_.promise().set_continuation(OwningCoroutineHandle<>(continuation));
-        return task_handle_;
+        schedule_coroutine_continuation(task_handle_);
       }
 
       T await_resume()

--- a/include/mrs_lib/geometry/misc.h
+++ b/include/mrs_lib/geometry/misc.h
@@ -55,7 +55,8 @@ namespace mrs_lib
      *
      * \returns the heading angle in the ENU frame (in radians).
      *
-     * \note By default, the function also wraps the angle to be in the interval [-pi; pi]. To change this, pass a different OutRangeT template parameter from the mrs_lib::cyclic library.
+     * \note By default, the function also wraps the angle to be in the interval [-pi; pi]. To change this, pass a different OutRangeT template parameter from
+     * the mrs_lib::cyclic library.
      */
     template <typename OutRangeT = sradians>
     double headingNEDtoENU(const double& heading_ned)
@@ -78,7 +79,8 @@ namespace mrs_lib
      *
      * \returns the heading angle in the NED frame (in radians).
      *
-     * \note By default, the function also wraps the angle to be in the interval [0; 2pi]. To change this, pass a different OutRangeT template parameter from the mrs_lib::cyclic library.
+     * \note By default, the function also wraps the angle to be in the interval [0; 2pi]. To change this, pass a different OutRangeT template parameter from
+     * the mrs_lib::cyclic library.
      */
     template <typename OutRangeT = radians>
     double headingENUtoNED(const double& heading_enu)

--- a/test/coro/test.cpp
+++ b/test/coro/test.cpp
@@ -89,6 +89,8 @@ namespace
   constexpr std::string_view test_exception_message = "Expected test exception";
   constexpr std::string_view test_not_thrown_exception_message = "This should not be thrown";
 
+  constexpr size_t deep_recursion_depth = 10'000'000;
+
   [[noreturn]] void throw_expected_exception()
   {
     throw std::logic_error(std::string(test_exception_message));
@@ -146,6 +148,17 @@ namespace
     auto a = co_await co_42();
     auto b = co_await co_uptr_42();
     co_return a + (*b);
+  }
+
+  mrs_lib::Task<int> co_42_recursive(size_t depth)
+  {
+    if (depth == 0)
+    {
+      co_return co_await co_42();
+    } else
+    {
+      co_return co_await co_42_recursive(depth - 1);
+    }
   }
 
   mrs_lib::Task<> co_throws_logic_error()
@@ -206,6 +219,8 @@ namespace
   struct ErrorOnMove
   {
     ErrorOnMove() = default;
+    ~ErrorOnMove() = default;
+
     ErrorOnMove(const ErrorOnMove&) = delete;
     ErrorOnMove& operator=(const ErrorOnMove&) = delete;
     ErrorOnMove(ErrorOnMove&&) noexcept(false)
@@ -398,6 +413,22 @@ namespace
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_2_times_42();
           EXPECT_EQ(val, 84);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, DeepRecursion)
+  {
+    bool finished = false;
+
+    mrs_lib::internal::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          int val = co_await co_42_recursive(deep_recursion_depth);
+          EXPECT_EQ(val, 42);
           finished = true;
           co_return;
         },


### PR DESCRIPTION
The same workaround was already used when exiting a task, with this change, it is also used when entering it.

This PR also includes regression test for the behavior.