### PR TITLE
Fix/root error behavior

### DIFF
--- a/include/mrs_lib/errorgraph/error_publisher.h
+++ b/include/mrs_lib/errorgraph/error_publisher.h
@@ -111,6 +111,17 @@ namespace mrs_lib
        */
       void addWaitingForTopicError(const std::string& topic_name);
 
+      /*!
+       * \brief Add a special error type `waiting_for_topic`.
+       * If the expected publisher of the topic is known, use this method to provide better information to the Errorgraph. If the expected publisher is unknown
+       * or can change, use the overload without the `expected_publisher` parameter instead.
+       *
+       * \param topic_name       Full name of the topic that is being waited for.
+       * \param expected_publisher  Identifier of the node and component that is expected to publish this topic.
+       */
+      void addWaitingForTopicError(const std::string& topic_name, const node_id_t& expected_publisher);
+
+
     private:
       rclcpp::Node::SharedPtr node_;
       rclcpp::Clock::SharedPtr clock_;

--- a/include/mrs_lib/errorgraph/errorgraph.h
+++ b/include/mrs_lib/errorgraph/errorgraph.h
@@ -111,7 +111,8 @@ namespace mrs_lib
         {
           if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_NODE)
             waited_for_node = node_id_t::from_msg(msg.waited_for_node);
-          else if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_TOPIC) {
+          else if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_TOPIC)
+          {
             waited_for_topic = msg.waited_for_topic;
             if (!msg.waited_for_node.node.empty() || !msg.waited_for_node.component.empty())
               waited_for_node = node_id_t::from_msg(msg.waited_for_node);

--- a/include/mrs_lib/errorgraph/errorgraph.h
+++ b/include/mrs_lib/errorgraph/errorgraph.h
@@ -111,8 +111,11 @@ namespace mrs_lib
         {
           if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_NODE)
             waited_for_node = node_id_t::from_msg(msg.waited_for_node);
-          else if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_TOPIC)
+          else if (msg.type == errorgraph_error_msg_t::TYPE_WAITING_FOR_TOPIC) {
             waited_for_topic = msg.waited_for_topic;
+            if (!msg.waited_for_node.node.empty() || !msg.waited_for_node.component.empty())
+              waited_for_node = node_id_t::from_msg(msg.waited_for_node);
+          }
           stamp = msg.stamp;
         }
 

--- a/src/errorgraph/error_publisher.cpp
+++ b/src/errorgraph/error_publisher.cpp
@@ -89,6 +89,27 @@ namespace mrs_lib
       errors_.push_back({std::nullopt, std::move(msg)});
     }
 
+    void ErrorPublisher::addWaitingForTopicError(const std::string& topic_name, const node_id_t& expected_publisher)
+    {
+      const auto now = clock_->now();
+      std::scoped_lock lck(errors_mtx_);
+      for (auto& error_wrapper : errors_)
+      {
+        if (error_wrapper.msg.type == mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_TOPIC && error_wrapper.msg.waited_for_topic == topic_name)
+        {
+          error_wrapper.msg.stamp = now;
+          return;
+        }
+      }
+      mrs_msgs::msg::ErrorgraphError msg;
+      msg.type = mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_TOPIC;
+      msg.stamp = now;
+      msg.waited_for_topic = topic_name;
+      msg.waited_for_node.node = expected_publisher.node;
+      msg.waited_for_node.component = expected_publisher.component;
+      errors_.push_back({std::nullopt, std::move(msg)});
+    }
+
     void ErrorPublisher::addWaitingForNodeError(const node_id_t& node_id)
     {
       const auto now = clock_->now();

--- a/src/errorgraph/errorgraph.cpp
+++ b/src/errorgraph/errorgraph.cpp
@@ -94,7 +94,7 @@ namespace mrs_lib
       std::vector<element_info_t> roots;
       for (const auto& el_ptr : elements_)
       {
-        if (!el_ptr->is_waiting_for() && !el_ptr->is_no_error())
+        if (!el_ptr->is_waiting_for() && (!el_ptr->is_no_error() || !el_ptr->parents.empty()))
           roots.push_back(el_ptr->to_info());
       }
       return roots;

--- a/src/errorgraph/errorgraph.cpp
+++ b/src/errorgraph/errorgraph.cpp
@@ -217,7 +217,7 @@ namespace mrs_lib
           {
             if (previous_el == nullptr)
             {
-              const node_id_t expected_node = error.waited_for_node.value_or(node_id_t{}); 
+              const node_id_t expected_node = error.waited_for_node.value_or(node_id_t{});
               add_new_element(topic_name, expected_node);
             }
           }

--- a/src/errorgraph/errorgraph.cpp
+++ b/src/errorgraph/errorgraph.cpp
@@ -207,12 +207,20 @@ namespace mrs_lib
         }
 
         // initialize all topics this node is waiting for if they do not exist
-        for (const auto& topic_name_ptr : el_ptr->waited_for_topics())
+        for (const auto& error : el_ptr->errors)
         {
-          const element_t* previous_el = find_element_mutable(*topic_name_ptr);
-          // if the element was not found, it may have not reported yet, initialize it
-          if (previous_el == nullptr)
-            add_new_element(*topic_name_ptr);
+          if (!error.is_waiting_for_topic())
+            continue;
+          const auto& topic_name = error.waited_for_topic.value();
+          const element_t* previous_el = find_element_mutable(topic_name);
+
+          {
+            if (previous_el == nullptr)
+            {
+              const node_id_t expected_node = error.waited_for_node.value_or(node_id_t{}); 
+              add_new_element(topic_name, expected_node);
+            }
+          }
         }
       }
       graph_up_to_date_ = false;
@@ -274,6 +282,13 @@ namespace mrs_lib
       errorgraph_element_msg_t ret;
       ret.stamp = stamp;
       ret.source_node = source_node.to_msg();
+
+      errorgraph_error_msg_t topic_error;
+      topic_error.stamp = stamp;
+      topic_error.type = mrs_msgs::msg::ErrorgraphError::TYPE_WAITING_FOR_TOPIC;
+      topic_error.waited_for_topic = topic_name;
+      topic_error.waited_for_node = source_node.to_msg();
+      ret.errors.push_back(topic_error);
       return ret;
     }
 

--- a/test/errorgraph/test.cpp
+++ b/test/errorgraph/test.cpp
@@ -204,7 +204,9 @@ TEST_F(ErrorgraphTest, find_error_roots_chain_of_dependencies)
 
 TEST_F(ErrorgraphTest, find_error_roots_waiting_with_no_error_dependency)
 {
-  // node2 is waiting for node1, but node1 has no errors
+  // node2 is waiting for node1, but node1 reports no errors.
+  // Even though node1 thinks it's OK, node2 is depending on it,
+  // so node1 should be identified as a root cause.
   auto msg1 = create_element_msg("node1", "comp1", {{errorgraph_error_msg_t::TYPE_NO_ERROR, ""}});
   auto msg2 = create_element_msg("node2", "comp2", {{errorgraph_error_msg_t::TYPE_WAITING_FOR_NODE, "node1.comp1"}});
 
@@ -213,8 +215,10 @@ TEST_F(ErrorgraphTest, find_error_roots_waiting_with_no_error_dependency)
 
   auto roots = graph_->find_error_roots();
 
-  // node1 has no error so it's not a root, node2 is waiting so it's not a root either
-  EXPECT_TRUE(roots.empty());
+  // node1 should be a root because node2 depends on it
+  ASSERT_EQ(roots.size(), 1);
+  const auto& info = std::get<Errorgraph::node_info_t>(roots[0]);
+  EXPECT_EQ(info.source_node.node, "node1");
 }
 
 //}
@@ -262,8 +266,12 @@ TEST_F(ErrorgraphTest, find_error_roots_waiting_for_topic)
 
   auto roots = graph_->find_error_roots();
 
-  // Node waiting for topic should NOT be an error root
-  EXPECT_TRUE(roots.empty());
+  // The waiting node should NOT be an error root (it's waiting).
+  // The topic element should be a root because someone depends on it.
+  ASSERT_EQ(roots.size(), 1);
+  ASSERT_TRUE(std::holds_alternative<Errorgraph::topic_info_t>(roots[0]));
+  const auto& topic = std::get<Errorgraph::topic_info_t>(roots[0]);
+  EXPECT_EQ(topic.topic_name, "/some/topic");
 }
 
 //}

--- a/test/run_specific_test.sh
+++ b/test/run_specific_test.sh
@@ -17,6 +17,6 @@ colcon test --packages-select mrs_lib --ctest-args -R 'param_provider'
 # colcon test --packages-select mrs_lib --ctest-args -R 'param_loader'
 # colcon test --packages-select mrs_lib --ctest-args -R 'dynparam_mgr'
 # colcon test --packages-select mrs_lib --ctest-args -R 'timeout_manager'
-# colcon test --packages-select mrs_lib --ctest-args -R 'safety_zone'
+colcon test --packages-select mrs_lib --ctest-args -R 'error_publisher'
 
 colcon test-result --all --verbose


### PR DESCRIPTION
## Summary

This pull request enhances error handling and root cause analysis in the `Errorgraph` module, particularly for nodes waiting on topics and dependencies. The main improvements include supporting more informative error reporting when waiting for topics, refining the logic for identifying root causes in dependency chains, and updating tests to reflect these changes.
- **What changed**:
    -  Added a new overload for `addWaitingForTopicError` in `error_publisher.h` and its implementation in `error_publisher.cpp` that allows specifying the expected publisher when reporting a waiting-for-topic error, providing more detailed information to the Errorgraph.
    -  Refined the logic in `find_error_roots` to consider nodes/topics as root causes if other elements depend on them, even if they themselves report no errors. 
        - Updated and documented the unit tests to reflect the new root cause analysis logic.
    - Improved the creation of topic error messages to include the source node information.

- **Why**:
    - Having a more accurate dependency graph makes it easier to identify errors or misconfigurations.
- **Notes for reviewers**:

## Impact
- **Affected areas**: None
- **Breaking changes**: No

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [] Tested on real HW