### PR TITLE
feat(param_loader,param_provider): add explicit parameter get result state for default values

### DIFF
--- a/include/mrs_lib/impl/param_loader.hpp
+++ b/include/mrs_lib/impl/param_loader.hpp
@@ -9,12 +9,12 @@ namespace mrs_lib
   /* printValue function and overloads //{ */
 
   template <typename T>
-  void ParamLoader::printValue(const resolved_name_t& name, const T& value) const
+  void ParamLoader::printValue(const resolved_name_t& name, const T& value, const std::string& suffix) const
   {
     if (m_node_name.empty())
-      std::cout << "\t" << name << ":\t" << value << std::endl;
+      std::cout << "\t" << name << ":\t" << value << suffix << std::endl;
     else
-      RCLCPP_INFO_STREAM(m_node->get_logger(), "[" << m_node_name << "]: parameter '" << name << "':\t" << value);
+      RCLCPP_INFO_STREAM(m_node->get_logger(), "[" << m_node_name << "]: parameter '" << name << "':\t" << value << suffix);
   }
 
   template <typename T>
@@ -269,10 +269,13 @@ namespace mrs_lib
 
     bool cur_load_successful = true;
     // try to load the parameter
-    const bool success = m_pp.getParam(resolved_name, loaded);
-    if (!success)
+    ParamProvider::get_options_t<T> opts;
+    if (optional)
+      opts.declare_options.default_value = default_value;
+    const auto result = m_pp.getParamResult(resolved_name, loaded, opts);
+    const bool success = result == ParamProvider::get_result_t::LOADED;
+    if (result == ParamProvider::get_result_t::FAILED)
     {
-      // if it was not loaded, set the default value
       loaded = default_value;
       if (!optional)
       {
@@ -286,7 +289,7 @@ namespace mrs_lib
     {
       // everything is fine and just print the resolved_name and value if required
       if (m_print_values)
-        printValue(resolved_name, loaded);
+        printValue(resolved_name, loaded, result == ParamProvider::get_result_t::DEFAULT ? " (default value)" : "");
       // mark the param resolved_name as successfully loaded
       m_loaded_params.insert(resolved_name);
     } else

--- a/include/mrs_lib/impl/param_loader.hpp
+++ b/include/mrs_lib/impl/param_loader.hpp
@@ -12,9 +12,9 @@ namespace mrs_lib
   void ParamLoader::printValue(const resolved_name_t& name, const T& value, const std::string& suffix) const
   {
     if (m_node_name.empty())
-      std::cout << "\t" << name << ":\t" << value << suffix << std::endl;
+      std::cout << "\t" << name << ":\t" << value << "\t" << suffix << std::endl;
     else
-      RCLCPP_INFO_STREAM(m_node->get_logger(), "[" << m_node_name << "]: parameter '" << name << "':\t" << value << suffix);
+      RCLCPP_INFO_STREAM(m_node->get_logger(), "[" << m_node_name << "]: parameter '" << name << "':\t" << value << "\t" << suffix);
   }
 
   template <typename T>

--- a/include/mrs_lib/impl/param_provider.hpp
+++ b/include/mrs_lib/impl/param_provider.hpp
@@ -82,11 +82,23 @@ namespace mrs_lib
   template <typename T>
   bool ParamProvider::getParam(const std::string& param_name, T& value_out) const
   {
-    return getParam(resolveName(param_name), value_out, {});
+    return getParamResult(resolveName(param_name), value_out, {}) != get_result_t::FAILED;
+  }
+
+  template <typename T>
+  ParamProvider::get_result_t ParamProvider::getParamResult(const std::string& param_name, T& value_out, const get_options_t<T>& opts) const
+  {
+    return getParamResult(resolveName(param_name), value_out, opts);
   }
 
   template <typename T>
   bool ParamProvider::getParam(const resolved_name_t& resolved_name, T& value_out, const get_options_t<T>& opts) const
+  {
+    return getParamResult(resolved_name, value_out, opts) != get_result_t::FAILED;
+  }
+
+  template <typename T>
+  ParamProvider::get_result_t ParamProvider::getParamResult(const resolved_name_t& resolved_name, T& value_out, const get_options_t<T>& opts) const
   {
     bool use_rosparam = m_use_rosparam;
     // the options structure always has precedence if the parameter is set
@@ -95,11 +107,11 @@ namespace mrs_lib
 
     // first, try to load from YAML, if enabled
     if (opts.use_yaml && loadFromYaml(resolved_name, value_out, opts))
-      return true;
+      return get_result_t::LOADED;
 
     // then, try to load from ROS, if enabled
     if (use_rosparam && loadFromROS(resolved_name, value_out, opts))
-      return true;
+      return get_result_t::LOADED;
 
     // if both fail, check for a default value
     if (opts.declare_options.default_value.has_value())
@@ -109,11 +121,11 @@ namespace mrs_lib
       if (opts.always_declare && !declareParam<T>(resolved_name, opts.declare_options))
       {
         RCLCPP_ERROR_STREAM(m_node->get_logger(), "Failed to declare parameter \"" << resolved_name << "\".");
-        return false;
+        return get_result_t::FAILED;
       }
 
       value_out = default_value;
-      return true;
+      return get_result_t::DEFAULT;
     }
 
     // if all options fail, return false
@@ -125,7 +137,7 @@ namespace mrs_lib
       ss << " in ROS,";
     ss << " no default value provided.";
     RCLCPP_ERROR_STREAM(m_node->get_logger(), ss.str());
-    return false;
+    return get_result_t::FAILED;
   }
   //}
 

--- a/include/mrs_lib/param_loader.h
+++ b/include/mrs_lib/param_loader.h
@@ -86,7 +86,7 @@ namespace mrs_lib
     /* printValue function and overloads //{ */
 
     template <typename T>
-    void printValue(const resolved_name_t& name, const T& value) const;
+    void printValue(const resolved_name_t& name, const T& value, const std::string& suffix = std::string()) const;
 
     //}
 

--- a/include/mrs_lib/param_provider.h
+++ b/include/mrs_lib/param_provider.h
@@ -128,6 +128,17 @@ namespace mrs_lib
       declare_options_t<T> declare_options = {};
     };
 
+    /** \brief Explicit result state for parameter loading. */
+    enum class get_result_t
+    {
+      /** \brief Parameter value loaded from YAML/ROS. */
+      LOADED,
+      /** \brief Parameter value resolved using provided default value. */
+      DEFAULT,
+      /** \brief Parameter value could not be resolved. */
+      FAILED,
+    };
+
     /** \brief Struct of options when setting a parameter to ROS.
      *
      * If the optionals are not filled (i.e. equal to std::nullopt), the values set in the ParamProvider class are used.
@@ -181,6 +192,21 @@ namespace mrs_lib
     bool getParam(const std::string& param_name, T& value_out) const;
 
     /*!
+     * \brief Gets the value of a parameter and returns an explicit result state.
+     *
+     * Firstly, the parameter is attempted to be loaded from the YAML files added by the addYamlFile() method
+     * in the same order that they were added. If the parameter is not found in any YAML file, and the use_rosparam
+     * flag of the constructor is true, the ParamProvider will declare it in ROS and attempt to load it from ROS.
+     *
+     * \param param_name      Name of the parameter to be loaded. Namespaces should be separated with a forward slash '/'.
+     * \param value_out       Output argument that will hold the value of the loaded parameter, if successfull. Not modified otherwise.
+     * \param opts            Options regarding getting and declaring the parameter (see the get_options_t<T> documentation).
+     * \return                Explicit loading result state.
+     */
+    template <typename T>
+    get_result_t getParamResult(const std::string& param_name, T& value_out, const get_options_t<T>& opts = {}) const;
+
+    /*!
      * \brief Gets the value of a parameter.
      *
      * Firstly, the parameter is attempted to be loaded from the YAML files added by the addYamlFile() method
@@ -194,6 +220,21 @@ namespace mrs_lib
      */
     template <typename T>
     bool getParam(const resolved_name_t& resolved_name, T& value_out, const get_options_t<T>& opts = {}) const;
+
+    /*!
+     * \brief Gets the value of a parameter and returns an explicit result state.
+     *
+     * Firstly, the parameter is attempted to be loaded from the YAML files added by the addYamlFile() method
+     * in the same order that they were added. If the parameter is not found in any YAML file, and the use_rosparam
+     * flag of the constructor is true, the ParamProvider will declare it in ROS and attempt to load it from ROS.
+     *
+     * \param resolved_name   Resolved parameter name.
+     * \param value_out       Output argument that will hold the value of the loaded parameter, if successfull. Not modified otherwise.
+     * \param opts            Options regarding getting and declaring the parameter (see the get_options_t<T> documentation).
+     * \return                Explicit loading result state.
+     */
+    template <typename T>
+    get_result_t getParamResult(const resolved_name_t& resolved_name, T& value_out, const get_options_t<T>& opts = {}) const;
 
     /*!
      * \brief Sets the value of a parameter to ROS.

--- a/test/param_loader/test.cpp
+++ b/test/param_loader/test.cpp
@@ -120,6 +120,17 @@ TEST_F(Test, param_loader_load_from_file)
 
   EXPECT_TRUE(pl.addYamlFile(test_resources_path.string() + "/test_config.yaml"));
 
+  int optional_missing_with_default = -1;
+  EXPECT_FALSE(pl.loadParam("missing_optional_param", optional_missing_with_default, 42));
+  EXPECT_EQ(optional_missing_with_default, 42);
+  EXPECT_TRUE(pl.loadedSuccessfully());
+
+  int compulsory_missing = -1;
+  EXPECT_FALSE(pl.loadParam("missing_compulsory_param", compulsory_missing));
+  EXPECT_EQ(compulsory_missing, 0);
+  EXPECT_FALSE(pl.loadedSuccessfully());
+  pl.resetLoadedSuccessfully();
+
   std::vector<Eigen::MatrixXd> loaded_nd_matrix = pl.loadMatrixArray2("test_param_nd_matrix");
   EXPECT_TRUE(pl.loadedSuccessfully());
 

--- a/test/param_provider/test.cpp
+++ b/test/param_provider/test.cpp
@@ -230,3 +230,38 @@ TEST_F(Test, param_provider_set)
 }
 
 //}
+
+/* TEST_F(Test, param_provider_get_param_result) //{ */
+
+TEST_F(Test, param_provider_get_param_result)
+{
+
+  initialize(rclcpp::NodeOptions().use_intra_process_comms(false));
+
+  auto clock = node_->get_clock();
+
+  auto pp = mrs_lib::ParamProvider(node_, false);
+  EXPECT_TRUE(pp.addYamlFile(test_resources_path.string() + "/test_config.yaml"));
+
+  int loaded_value = 0;
+  EXPECT_EQ(pp.getParamResult("param_provider/test_int", loaded_value), mrs_lib::ParamProvider::get_result_t::LOADED);
+  EXPECT_EQ(loaded_value, 666);
+
+  int defaulted_value = 0;
+  const auto default_opts = mrs_lib::ParamProvider::get_options_t<int>{.declare_options = {.default_value = 42}};
+  EXPECT_EQ(pp.getParamResult("param_provider/nonexistent_param", defaulted_value, default_opts), mrs_lib::ParamProvider::get_result_t::DEFAULT);
+  EXPECT_EQ(defaulted_value, 42);
+  EXPECT_TRUE(pp.getParam(pp.resolveName("param_provider/nonexistent_param"), defaulted_value, default_opts));
+  EXPECT_EQ(defaulted_value, 42);
+
+  int missing_value = -1;
+  EXPECT_EQ(pp.getParamResult("param_provider/nonexistent_param_without_default", missing_value), mrs_lib::ParamProvider::get_result_t::FAILED);
+  EXPECT_FALSE(pp.getParam("param_provider/nonexistent_param_without_default", missing_value));
+  EXPECT_EQ(missing_value, -1);
+
+  despin();
+
+  clock->sleep_for(1s);
+}
+
+//}


### PR DESCRIPTION
## Summary
Currently, the error message is presented even when a default value is provided to param_loader. Which is misleading. See example below:
```sh
[component_container_mt-1] [ERROR] [1780918544.698606527] [uav1.state_monitor]: Param 'robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/node' not found: in YAML files, in ROS, no default value provided.
[component_container_mt-1] [ERROR] [1780918544.698640412] [uav1.state_monitor]: Param 'robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/component' not found: in YAML files, in ROS, no default value provided.
[component_container_mt-1]      robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/node:  HwApiManager
[component_container_mt-1]      robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/component:     main
```

This PR removes the error message when a default value is provided and adds the value suffix `(default value)` when the loaded variable is printed.

See the same example:
```bash
[component_container_mt-1]      robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/node:     HwApiManager       (default value)                                                                                                                   
[component_container_mt-1]      robot_diagnostics/sensor_handlers/Rangefinder/expected_publisher/component:        main       (default value)                                                                                            
```

## Impact
- **Affected areas**: None
- **Breaking changes**: No

There will be no error for the user that default value has not been provided. 

## Testing status
- **What was tested**:
    * [x] Build/test passes
    * [x] Tests updated if needed
    * [x] Tested in simulation
    * [] Tested on real HW

- **How to repeat tests**:
 ```bash
 See test examples.

