### PR TITLE
Update coroutines library - namespace, cancellation and refactoring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,7 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/coro/task.impl.hpp"
     # include/mrs_lib/coro/internal
     "include/mrs_lib/coro/internal/attributes.hpp"
+    "include/mrs_lib/coro/internal/result_storage.hpp"
     "include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
     # include/mrs_lib/errorgraph
     "include/mrs_lib/errorgraph/node_id.h"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,8 @@ target_sources(mrs_lib_mrs_lib
     # src/batch_visualizer
     "src/batch_visualizer/batch_visualizer.cpp"
     "src/batch_visualizer/visual_object.cpp"
+    # src/coro
+    "src/coro/cancellation.cpp"
     # src/coro/internal
     "src/coro/internal/thread_local_continuation_scheduler.cpp"
     # src/dynparam_mgr
@@ -161,11 +163,13 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/utils.h"
     "include/mrs_lib/visual_object.h"
     # include/mrs_lib/coro
+    "include/mrs_lib/coro/cancellation.hpp"
     "include/mrs_lib/coro/runners.hpp"
     "include/mrs_lib/coro/task.hpp"
     "include/mrs_lib/coro/task.impl.hpp"
     # include/mrs_lib/coro/internal
     "include/mrs_lib/coro/internal/attributes.hpp"
+    "include/mrs_lib/coro/internal/continuation.hpp"
     "include/mrs_lib/coro/internal/result_storage.hpp"
     "include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
     # include/mrs_lib/errorgraph

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,7 @@ target_sources(mrs_lib_mrs_lib
     # include/mrs_lib/coro/internal
     "include/mrs_lib/coro/internal/attributes.hpp"
     "include/mrs_lib/coro/internal/continuation.hpp"
+    "include/mrs_lib/coro/internal/immediate_awaitable.hpp"
     "include/mrs_lib/coro/internal/result_storage.hpp"
     "include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
     # include/mrs_lib/errorgraph

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,8 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/safety_zone/polygon.h"
     "include/mrs_lib/safety_zone/prism.h"
     "include/mrs_lib/safety_zone/static_edges_visualization.h"
+    # include/mrs_lib/utility
+    "include/mrs_lib/utility/scope_cleanup.hpp"
 )
 
 target_link_libraries(mrs_lib_mrs_lib

--- a/include/mrs_lib/coro/cancellation.hpp
+++ b/include/mrs_lib/coro/cancellation.hpp
@@ -1,0 +1,47 @@
+#ifndef MRS_LIB_CORO_CANCELLATION_HPP_
+#define MRS_LIB_CORO_CANCELLATION_HPP_
+
+
+#include <cassert>
+#include <coroutine>
+#include <stop_token>
+
+#include "mrs_lib/coro/internal/continuation.hpp"
+
+
+namespace mrs_lib::coro
+{
+
+  namespace internal
+  {
+
+    class [[nodiscard]] GetTaskStopTokenAwaiter
+    {
+    public:
+      bool await_ready();
+
+      template <typename T>
+      bool await_suspend(std::coroutine_handle<T> handle)
+      {
+        return await_suspend(CancellableContinuation(handle));
+      }
+      bool await_suspend(CancellableContinuation continuation);
+
+      std::stop_token await_resume();
+
+    private:
+      std::stop_token token_;
+    };
+
+  } // namespace internal
+
+  /**
+   * @brief Get awaitable that will return stop token associated with the current coroutine.
+   *
+   * @note Return value must be awaited.
+   */
+  internal::GetTaskStopTokenAwaiter get_task_stop_token();
+
+} // namespace mrs_lib::coro
+
+#endif // MRS_LIB_CORO_CANCELLATION_HPP_

--- a/include/mrs_lib/coro/cancellation.hpp
+++ b/include/mrs_lib/coro/cancellation.hpp
@@ -7,6 +7,7 @@
 #include <stop_token>
 
 #include "mrs_lib/coro/internal/continuation.hpp"
+#include "mrs_lib/coro/internal/immediate_awaitable.hpp"
 
 
 namespace mrs_lib::coro
@@ -40,7 +41,7 @@ namespace mrs_lib::coro
    *
    * @note Return value must be awaited.
    */
-  internal::GetTaskStopTokenAwaiter get_task_stop_token();
+  internal::ImmediateAwaitable<internal::GetTaskStopTokenAwaiter> get_task_stop_token();
 
 } // namespace mrs_lib::coro
 

--- a/include/mrs_lib/coro/internal/continuation.hpp
+++ b/include/mrs_lib/coro/internal/continuation.hpp
@@ -1,0 +1,179 @@
+#ifndef MRS_LIB_CORO_INTERNAL_CONTINUATION_HPP_
+#define MRS_LIB_CORO_INTERNAL_CONTINUATION_HPP_
+
+
+#include <coroutine>
+#include <functional>
+#include <stop_token>
+#include <utility>
+
+namespace mrs_lib::coro::internal
+{
+
+  /**
+   * @brief Cast coroutine handle to the specified promise type.
+   *
+   * @tparam T Coroutine promise type to cast to.
+   * @param handle Coroutine handle to cast.
+   *
+   * @warning Causes undefined behavior if the stored promise type is not the exact type we requested.
+   */
+  template <typename T>
+  std::coroutine_handle<T> coroutine_handle_reinterpret_cast(std::coroutine_handle<> handle)
+  {
+    return std::coroutine_handle<T>::from_address(handle.address());
+  }
+
+  /**
+   * @brief Type trait to obtain data necessary for creating CancellableContinuation.
+   *
+   * This type must be specialized for the correct promise type. The default template is undefined.
+   *
+   * Required members in specializations:
+   * - `static CancellableContinuation release_continuation(std::coroutine_handle<T>)`
+   * - `static std::stop_token get_token(std::coroutine_handle<T>)`
+   */
+  template <typename T>
+  struct CancellableContinuationFor;
+
+  template <>
+  struct CancellableContinuationFor<void>
+  {
+  };
+
+  /**
+   * @brief Owning coroutine handle supporting cancellation.
+   *
+   * This class can be used to hold coroutine handle as owner. If it is
+   * destroyed while holding a handle, it cancels the coroutine.
+   *
+   * Coroutine cancellation is performed in a way that should not exhaust stack
+   * space.
+   */
+  class CancellableContinuation
+  {
+  private:
+    template <typename T>
+    using ContinuationGetterFptr = CancellableContinuation (*)(std::coroutine_handle<T>);
+    template <typename T>
+    using TokenGetterFptr = std::stop_token (*)(std::coroutine_handle<T>);
+
+  public:
+    /**
+     * @brief Construct empty continuation.
+     */
+    CancellableContinuation() = default;
+
+    /**
+     * @brief Cancellable continuation cannot be constructed from type erased handle.
+     */
+    explicit CancellableContinuation(std::coroutine_handle<void>) = delete;
+
+    /**
+     * @brief Construct continuation that will own the passed handle.
+     *
+     * @param handle Handle to the continuation to store.
+     */
+    template <typename T>
+    explicit CancellableContinuation(std::coroutine_handle<T> handle)
+        : data_{
+              .func = [](std::coroutine_handle<> handle) -> CancellableContinuation {
+                using Trait = CancellableContinuationFor<T>;
+                static_assert(std::same_as<decltype(&Trait::release_continuation), ContinuationGetterFptr<T>>,
+                              "Wrong signature for CancellableContinuationFor<T>::release_continuation.");
+                static_assert(std::same_as<decltype(&Trait::get_token), TokenGetterFptr<T>>, "Wrong signature for CancellableContinuationFor<T>::get_token.");
+                return Trait::release_continuation(coroutine_handle_reinterpret_cast<T>(handle));
+              },
+              .handle = handle,
+              .stop_token = CancellableContinuationFor<T>::get_token(coroutine_handle_reinterpret_cast<T>(handle)),
+          }
+    {
+    }
+
+    /**
+     * @brief Destroy stored continuation if there is any.
+     */
+    ~CancellableContinuation()
+    {
+      cancel_and_destroy();
+    }
+
+    CancellableContinuation(const CancellableContinuation&) = delete;
+    CancellableContinuation& operator=(const CancellableContinuation&) = delete;
+    CancellableContinuation(CancellableContinuation&& other) noexcept : data_(std::exchange(other.data_, {}))
+    {
+    }
+    CancellableContinuation& operator=(CancellableContinuation&& other) noexcept
+    {
+      std::ranges::swap(data_, other.data_);
+      return *this;
+    }
+
+    /**
+     * @brief Release ownership of the stored handle, giving it to the caller.
+     *
+     * The continuation will be empty after this call.
+     */
+    std::coroutine_handle<> release()
+    {
+      return std::exchange(data_.handle, nullptr);
+    }
+
+    /**
+     * @brief Cancel the stored continuation, if there is any.
+     *
+     * The continuation will be empty after this call.
+     */
+    void cancel_and_destroy()
+    {
+      ContinuationData local_data = release_data();
+
+      while (local_data.handle != nullptr)
+      {
+        CancellableContinuation continuation = std::invoke(local_data.func, local_data.handle);
+        local_data.handle.destroy();
+        local_data = continuation.release_data();
+      }
+    }
+
+    /**
+     * @brief Get stop token associated with the continuation.
+     */
+    std::stop_token get_token() const
+    {
+      return data_.stop_token;
+    }
+
+    /**
+     * @brief Check if the current continuation is empty.
+     */
+    friend bool operator==(const CancellableContinuation& continuation, std::nullptr_t)
+    {
+      return continuation.data_.handle == nullptr;
+    }
+
+  private:
+    /**
+     * @brief Internal data of CancellableContinuation.
+     */
+    struct ContinuationData
+    {
+      ContinuationGetterFptr<void> func = nullptr;
+      std::coroutine_handle<> handle = nullptr;
+      std::stop_token stop_token{};
+    };
+
+    /**
+     * @brief Release the data stored by the continuation. It will be empty after this call.
+     */
+    ContinuationData release_data()
+    {
+      return std::exchange(data_, {});
+    }
+
+    ContinuationData data_;
+  };
+
+} // namespace mrs_lib::coro::internal
+
+#endif // MRS_LIB_CORO_INTERNAL_CONTINUATION_HPP_

--- a/include/mrs_lib/coro/internal/immediate_awaitable.hpp
+++ b/include/mrs_lib/coro/internal/immediate_awaitable.hpp
@@ -1,0 +1,45 @@
+#ifndef MRS_LIB_CORO_INTERNAL_IMMEDIATE_AWAITABLE_HPP_
+#define MRS_LIB_CORO_INTERNAL_IMMEDIATE_AWAITABLE_HPP_
+
+
+#include <utility>
+
+
+namespace mrs_lib::coro::internal
+{
+
+  /**
+   * @brief Helper class to force awaiting a result in the current expression.
+   */
+  template <typename Awaiter>
+  class [[nodiscard("The result must be awaited, otherwise, it may do NOTHING!!!")]] ImmediateAwaitable
+  {
+
+  public:
+    ImmediateAwaitable()
+      requires std::default_initializable<Awaiter>
+    = default;
+    ImmediateAwaitable(Awaiter awaiter) : awaiter_(std::move(awaiter))
+    {
+    }
+
+    ~ImmediateAwaitable() = default;
+
+    ImmediateAwaitable(const ImmediateAwaitable&) = delete;
+    ImmediateAwaitable(ImmediateAwaitable&&) = delete;
+    ImmediateAwaitable& operator=(const ImmediateAwaitable&) = delete;
+    ImmediateAwaitable& operator=(ImmediateAwaitable&&) = delete;
+
+    friend Awaiter operator co_await(ImmediateAwaitable awaitable)
+    {
+      return std::move(awaitable).awaiter_;
+    }
+
+  private:
+    Awaiter awaiter_{};
+  };
+
+} // namespace mrs_lib::coro::internal
+
+
+#endif // MRS_LIB_CORO_INTERNAL_IMMEDIATE_AWAITABLE_HPP_

--- a/include/mrs_lib/coro/internal/result_storage.hpp
+++ b/include/mrs_lib/coro/internal/result_storage.hpp
@@ -1,0 +1,81 @@
+#ifndef MRS_LIB_CORO_INTERNAL_RESULT_STORAGE_HPP_
+#define MRS_LIB_CORO_INTERNAL_RESULT_STORAGE_HPP_
+
+
+#include <cstddef>
+#include <exception>
+#include <variant>
+
+
+namespace mrs_lib::coro::internal
+{
+
+  /**
+   * @brief A variant-like class for storing the result of non-void task.
+   */
+  template <typename T>
+  class ResultStorage
+  {
+  private:
+    // Not enum class to allow usage in functions like std::get
+    enum State : size_t
+    {
+      empty = 0,
+      value = 1,
+      exception = 2,
+    };
+
+  public:
+    constexpr ResultStorage() noexcept : data_()
+    {
+    }
+
+    /**
+     * @brief Store result of task.
+     *
+     * This can only be called once and not if set_exception was called.
+     */
+    constexpr void set_value(T&& val) noexcept(std::is_nothrow_move_constructible_v<T>)
+    {
+      assert(data_.index() == State::empty);
+      data_.template emplace<State::value>(std::move(val));
+    }
+
+    /**
+     * @brief Store exception into the result.
+     *
+     * This can only ve called once and not if set_value was called (unless it failed with exception).
+     */
+    void set_exception(std::exception_ptr eptr) noexcept
+    {
+      assert(data_.index() == State::empty || data_.valueless_by_exception());
+      data_.template emplace<State::exception>(std::move(eptr));
+    }
+
+    /**
+     * @brief Get previously stored result or exception.
+     *
+     * If this result contains a value, it is returned. Otherwise, if there is
+     * an exception stored, it is thrown.
+     *
+     * Either set_value or set_exception must be called before calling this.
+     */
+    constexpr T get_value() &&
+    {
+      size_t state = data_.index();
+      if (state == State::exception)
+      {
+        std::rethrow_exception(std::get<State::exception>(data_));
+      }
+      assert(state == State::value);
+      return std::get<State::value>(std::move(data_));
+    }
+
+  private:
+    std::variant<std::monostate, T, std::exception_ptr> data_;
+  };
+
+} // namespace mrs_lib::coro::internal
+
+
+#endif // MRS_LIB_CORO_INTERNAL_RESULT_STORAGE_HPP_

--- a/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
+++ b/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
@@ -9,7 +9,7 @@ namespace mrs_lib::coro::internal
 
   // This is a workaround to GCC generated code overflowing stack when using symmetric transfer
 
-  void resume_coroutine(std::coroutine_handle<> handle);
+  void resume_coroutine_soon(std::coroutine_handle<> handle);
   void schedule_coroutine_continuation(std::coroutine_handle<> handle);
 
   struct MoveToThreadLocalContinuationScheduler
@@ -27,10 +27,10 @@ namespace mrs_lib::coro::internal
       return false;
     }
 
-    // Move the task to the thread local scheduler
+    // Move the task to the thread local scheduler to be scheduled soon
     void await_suspend(std::coroutine_handle<> task_handle) noexcept
     {
-      resume_coroutine(task_handle);
+      resume_coroutine_soon(task_handle);
     }
 
     // The task is moved, return nothing

--- a/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
+++ b/include/mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp
@@ -4,7 +4,7 @@
 
 #include <coroutine>
 
-namespace mrs_lib::internal
+namespace mrs_lib::coro::internal
 {
 
   // This is a workaround to GCC generated code overflowing stack when using symmetric transfer
@@ -39,7 +39,7 @@ namespace mrs_lib::internal
     }
   };
 
-} // namespace mrs_lib::internal
+} // namespace mrs_lib::coro::internal
 
 
 #endif // MRS_LIB_CORO_INTERNAL_THREAD_LOCAL_CONTINUATION_SCHEDULER_HPP_

--- a/include/mrs_lib/coro/runners.hpp
+++ b/include/mrs_lib/coro/runners.hpp
@@ -8,7 +8,7 @@
 #include <mrs_lib/coro/task.hpp>
 
 
-namespace mrs_lib
+namespace mrs_lib::coro
 {
 
   namespace internal
@@ -87,6 +87,6 @@ namespace mrs_lib
 
   } // namespace internal
 
-} // namespace mrs_lib
+} // namespace mrs_lib::coro
 
 #endif // MRS_LIB_CORO_RUNNERS_HPP_

--- a/include/mrs_lib/coro/runners.hpp
+++ b/include/mrs_lib/coro/runners.hpp
@@ -6,6 +6,8 @@
 
 #include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
 #include <mrs_lib/coro/task.hpp>
+#include <stop_token>
+#include <utility>
 
 
 namespace mrs_lib::coro
@@ -26,9 +28,17 @@ namespace mrs_lib::coro
     public:
       struct promise_type
       {
+        /**
+         * @brief Construct the promise type, storing the associated stop token.
+         */
+        template <typename... Args>
+        promise_type(std::stop_token stop_token, Args&&...) : stop_token_(std::move(stop_token))
+        {
+        }
+
         AsyncRun get_return_object()
         {
-          return AsyncRun();
+          return {};
         }
         MoveToThreadLocalContinuationScheduler initial_suspend()
         {
@@ -45,22 +55,44 @@ namespace mrs_lib::coro
         {
           throw;
         }
+
+        std::stop_token stop_token_;
       };
 
     private:
       AsyncRun() = default;
     };
 
-    template <class T>
-      requires std::convertible_to<T, std::decay_t<T>>
-    constexpr std::decay_t<T> decay_copy(T&& value) noexcept(std::is_nothrow_convertible_v<T, std::decay_t<T>>)
+    template <>
+    struct CancellableContinuationFor<AsyncRun::promise_type>
     {
-      return std::forward<T>(value);
-    }
+      static CancellableContinuation release_continuation(std::coroutine_handle<AsyncRun::promise_type>)
+      {
+        return {};
+      };
 
+      static std::stop_token get_token(std::coroutine_handle<AsyncRun::promise_type> handle)
+      {
+        return handle.promise().stop_token_;
+      }
+    };
+
+    /**
+     * @brief Internal helper to safely start coroutine task.
+     *
+     * @param stop_token The stop token is used by the internal::AsyncRun promise object.
+     * @param task Coroutine to start
+     * @param args Additional arguments to the coroutine
+     *
+     * All arguments are taken by value to ensure that they are copied into
+     * the coroutine frame, thus preventing dangling references similarly
+     * to `std::thread`.
+     *
+     * @see start_task
+     */
     template <typename F, typename... Args>
       requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
-    internal::AsyncRun start_task_impl(F task, Args... args)
+    internal::AsyncRun start_task_impl(std::stop_token, F task, Args... args)
     {
       // The `decay-copy` of the arguments ensures that they are copied into
       // the coroutine frame, preventing dangling references like `std::thread`.
@@ -69,6 +101,9 @@ namespace mrs_lib::coro
 
     /**
      * @brief Start execution of a task from outside of a coroutine.
+     *
+     * @param task The coroutine task to start.
+     * @param args Additional arguments to the task.
      *
      * This function starts the execution of the coroutine using the provided
      * arguments. The passed arguments are decay-copied into the coroutine frame
@@ -82,7 +117,29 @@ namespace mrs_lib::coro
       requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
     void start_task(F&& task, Args&&... args)
     {
-      internal::start_task_impl(std::forward<F>(task), std::forward<Args>(args)...);
+      internal::start_task_impl(std::stop_token(), std::forward<F>(task), std::forward<Args>(args)...);
+    }
+
+    /**
+     * @brief Start execution of a task from outside of a coroutine.
+     *
+     * @param token Stop token that can be used to interrupt execution of the task.
+     * @param task The coroutine task to start.
+     * @param args Additional arguments to the task.
+     *
+     * This function starts the execution of the coroutine using the provided
+     * arguments. The passed arguments are decay-copied into the coroutine frame
+     * (similarly to std::thread).
+     *
+     * Using this function from user code is not usually necessary. It can be
+     * avoided by `co_await`ing the tasks and using callbacks that support passing
+     * coroutine callbacks.
+     */
+    template <typename F, typename... Args>
+      requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
+    void start_task(std::stop_token token, F&& task, Args&&... args)
+    {
+      internal::start_task_impl(token, std::forward<F>(task), std::forward<Args>(args)...);
     }
 
   } // namespace internal

--- a/include/mrs_lib/coro/runners.hpp
+++ b/include/mrs_lib/coro/runners.hpp
@@ -60,11 +60,11 @@ namespace mrs_lib::coro
 
     template <typename F, typename... Args>
       requires std::invocable<std::decay_t<F>, std::decay_t<Args>...> && std::same_as<Task<void>, std::invoke_result_t<std::decay_t<F>, std::decay_t<Args>...>>
-    internal::AsyncRun start_task_impl(F&& task, Args&&... args)
+    internal::AsyncRun start_task_impl(F task, Args... args)
     {
       // The `decay-copy` of the arguments ensures that they are copied into
       // the coroutine frame, preventing dangling references like `std::thread`.
-      co_await std::invoke(decay_copy(std::forward<F>(task)), decay_copy(std::forward<Args>(args))...);
+      co_await std::invoke(std::move(task), std::move(args)...);
     }
 
     /**

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -9,8 +9,8 @@
 #include <type_traits>
 #include <utility>
 
-#include <mrs_lib/coro/internal/attributes.hpp>
-#include <variant>
+#include "mrs_lib/coro/internal/attributes.hpp"
+#include "mrs_lib/coro/internal/result_storage.hpp"
 
 // Note on ownership semantics:
 // Since we want to support cancellation at any point in the coroutine stacks,
@@ -116,71 +116,6 @@ namespace mrs_lib::coro
 
     private:
       OwningCoroutineHandle<> continuation_{std::noop_coroutine()};
-    };
-
-    /**
-     * @brief A variant-like class for storing the result of non-void task.
-     */
-    template <typename T>
-    class ResultStorage
-    {
-    private:
-      // Not enum class to allow usage in functions like std::get
-      enum State : size_t
-      {
-        empty = 0,
-        value = 1,
-        exception = 2,
-      };
-
-    public:
-      constexpr ResultStorage() noexcept : data_()
-      {
-      }
-
-      /**
-       * @brief Store result of task.
-       *
-       * This can only ve called once and not if set_exception was called.
-       */
-      constexpr void set_value(T&& val) noexcept(std::is_nothrow_move_constructible_v<T>)
-      {
-        assert(data_.index() == State::empty);
-        data_.template emplace<State::value>(std::move(val));
-      }
-
-      /**
-       * @brief Store exception into the result.
-       *
-       * This can only ve called once and not if set_value was called.
-       */
-      void set_exception(std::exception_ptr eptr) noexcept
-      {
-        assert(data_.index() == State::empty || data_.valueless_by_exception());
-        data_.template emplace<State::exception>(std::move(eptr));
-      }
-
-      /**
-       * @brief Get previously stored result or exception.
-       *
-       * If this result contains a value, it is returned. Otherwise, if there is
-       * an exception stored, it is thrown.
-       *
-       * Either set_value or set_exception must be called before calling this.
-       */
-      constexpr T get_value() &&
-      {
-        size_t state = data_.index();
-        if (state == State::exception)
-        {
-          std::rethrow_exception(std::get<State::exception>(data_));
-        }
-        assert(state == State::value);
-        return std::get<State::value>(std::move(data_));
-      }
-
-    private:
-      std::variant<std::monostate, T, std::exception_ptr> data_;
     };
 
     /**

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -10,7 +10,9 @@
 #include <utility>
 
 #include "mrs_lib/coro/internal/attributes.hpp"
+#include "mrs_lib/coro/internal/continuation.hpp"
 #include "mrs_lib/coro/internal/result_storage.hpp"
+#include "mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
 
 // Note on ownership semantics:
 // Since we want to support cancellation at any point in the coroutine stacks,
@@ -112,10 +114,20 @@ namespace mrs_lib::coro
       // The coroutine will be suspended and the continuation will be resumed
       FinalAwaitable final_suspend() noexcept;
 
-      void set_continuation(OwningCoroutineHandle<> continuation);
+      void set_continuation(CancellableContinuation continuation);
+
+      CancellableContinuation release_continuation()
+      {
+        return std::exchange(continuation_, {});
+      }
+
+      std::stop_token get_token() const
+      {
+        return continuation_.get_token();
+      }
 
     private:
-      OwningCoroutineHandle<> continuation_{std::noop_coroutine()};
+      CancellableContinuation continuation_;
     };
 
     /**
@@ -169,6 +181,21 @@ namespace mrs_lib::coro
       std::exception_ptr exception_;
     };
 
+    template <typename T>
+    struct CancellableContinuationFor<PromiseType<T>>
+    {
+      static CancellableContinuation release_continuation(std::coroutine_handle<PromiseType<T>> handle)
+      {
+        PromiseType<T>& promise = handle.promise();
+        return promise.release_continuation();
+      };
+
+      static std::stop_token get_token(std::coroutine_handle<PromiseType<T>> handle)
+      {
+        return handle.promise().get_token();
+      }
+    };
+
     /**
      * @brief Awaitable used to co_await other tasks.
      *
@@ -191,9 +218,10 @@ namespace mrs_lib::coro
       // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100897
       // Because of this problem, the `await_suspend` uses the void signature
       // and resumes the continuation on a thread-local scheduler as a workaround.
-      void await_suspend(std::coroutine_handle<> continuation)
+      template <typename CallerPromise>
+      void await_suspend(std::coroutine_handle<CallerPromise> continuation)
       {
-        task_handle_.promise().set_continuation(OwningCoroutineHandle<>(continuation));
+        task_handle_.promise().set_continuation(CancellableContinuation(continuation));
         schedule_coroutine_continuation(task_handle_);
       }
 
@@ -248,7 +276,7 @@ namespace mrs_lib::coro
     }
 
   private:
-    Task(internal::OwningCoroutineHandle<promise_type> coroutine) : coroutine_(std::move(coroutine))
+    explicit Task(internal::OwningCoroutineHandle<promise_type> coroutine) : coroutine_(std::move(coroutine))
     {
     }
 
@@ -261,11 +289,14 @@ namespace mrs_lib::coro
 
 namespace mrs_lib
 {
+  // Export mrs_lib::coro::Task directly into mrs_lib namespace since it is
+  // likely to be used often.
   using coro::Task;
-}
+
+} // namespace mrs_lib
 
 #ifndef MRS_LIB_CORO_TASK_IMPL_HPP_
-#include <mrs_lib/coro/task.impl.hpp> // IWYU pragma: export
+#include "mrs_lib/coro/task.impl.hpp" // IWYU pragma: export
 #endif
 
 #endif // MRS_LIB_CORO_TASK_HPP_

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -19,7 +19,7 @@
 // either suspend and become continuation of some other task thus transferring
 // ownership or destruct itself once completed.
 
-namespace mrs_lib
+namespace mrs_lib::coro
 {
 
   template <typename T = void>
@@ -322,7 +322,12 @@ namespace mrs_lib
     friend class internal::PromiseType<T>;
   };
 
-} // namespace mrs_lib
+} // namespace mrs_lib::coro
+
+namespace mrs_lib
+{
+  using coro::Task;
+}
 
 #ifndef MRS_LIB_CORO_TASK_IMPL_HPP_
 #include <mrs_lib/coro/task.impl.hpp> // IWYU pragma: export

--- a/include/mrs_lib/coro/task.impl.hpp
+++ b/include/mrs_lib/coro/task.impl.hpp
@@ -1,8 +1,8 @@
 #ifndef MRS_LIB_CORO_TASK_IMPL_HPP_
 #define MRS_LIB_CORO_TASK_IMPL_HPP_
 
-#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
-#include <mrs_lib/coro/task.hpp>
+#include "mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
+#include "mrs_lib/coro/task.hpp"
 
 namespace mrs_lib::coro
 {
@@ -41,7 +41,7 @@ namespace mrs_lib::coro
     }
 
     template <typename Derived>
-    inline void BasePromiseType<Derived>::set_continuation(OwningCoroutineHandle<> continuation)
+    inline void BasePromiseType<Derived>::set_continuation(CancellableContinuation continuation)
     {
       continuation_ = std::move(continuation);
     }

--- a/include/mrs_lib/coro/task.impl.hpp
+++ b/include/mrs_lib/coro/task.impl.hpp
@@ -4,7 +4,7 @@
 #include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
 #include <mrs_lib/coro/task.hpp>
 
-namespace mrs_lib
+namespace mrs_lib::coro
 {
   namespace internal
   {
@@ -79,7 +79,7 @@ namespace mrs_lib
     }
 
   } // namespace internal
-} // namespace mrs_lib
+} // namespace mrs_lib::coro
 
 
 #endif // MRS_LIB_CORO_TASK_IMPL_HPP_

--- a/include/mrs_lib/impl/service_client_handler.hpp
+++ b/include/mrs_lib/impl/service_client_handler.hpp
@@ -50,7 +50,7 @@ namespace mrs_lib
                                      data->response = future.get();
                                      (*data).response = future.get();
                                      auto continuation = std::exchange(data->continuation, nullptr);
-                                     coro::internal::resume_coroutine(continuation);
+                                     coro::internal::resume_coroutine_soon(continuation);
                                    }));
         return true;
       }

--- a/include/mrs_lib/impl/service_client_handler.hpp
+++ b/include/mrs_lib/impl/service_client_handler.hpp
@@ -50,7 +50,7 @@ namespace mrs_lib
                                      data->response = future.get();
                                      (*data).response = future.get();
                                      auto continuation = std::exchange(data->continuation, nullptr);
-                                     internal::resume_coroutine(continuation);
+                                     coro::internal::resume_coroutine(continuation);
                                    }));
         return true;
       }

--- a/include/mrs_lib/impl/service_server_handler.hpp
+++ b/include/mrs_lib/impl/service_server_handler.hpp
@@ -69,7 +69,7 @@ namespace mrs_lib
 
       if (!was_running)
       {
-        internal::start_task(
+        coro::internal::start_task(
             [](std::shared_ptr<typename rclcpp::Service<ServiceType>::SharedPtr> server, // Pass the captured safe pointer
                std::shared_ptr<std::atomic<bool>> is_running,
                mrs_lib::Task<bool> (ClassType::*method)(const std::shared_ptr<typename ServiceType::Request>,

--- a/include/mrs_lib/subscriber_handler.h
+++ b/include/mrs_lib/subscriber_handler.h
@@ -509,7 +509,7 @@ namespace mrs_lib
 
         if (!was_running)
         {
-          internal::start_task(
+          coro::internal::start_task(
               [](std::shared_ptr<std::atomic<bool>> is_running, Task<> (C::*method)(typename MessageType::ConstSharedPtr msg), C* instance,
                  typename MessageType::ConstSharedPtr msg) -> mrs_lib::Task<void> {
                 // Run the user specified callback. We co_await it, but we do not

--- a/include/mrs_lib/timer_handler.h
+++ b/include/mrs_lib/timer_handler.h
@@ -104,7 +104,7 @@ namespace mrs_lib
         if (!was_running)
         {
           // The callback was not running and we have set it as running, we start it here.
-          internal::start_task(
+          coro::internal::start_task(
               // Capturing lambdas should not be used as coroutines.
               // Pass the values as arguments instead.
               [](std::shared_ptr<std::atomic<bool>> is_running, Task<> (C::*method)(), C* instance) -> mrs_lib::Task<> {

--- a/include/mrs_lib/utility/scope_cleanup.hpp
+++ b/include/mrs_lib/utility/scope_cleanup.hpp
@@ -1,0 +1,57 @@
+#ifndef MRS_LIB_UTILITY_SCOPE_CLEANUP_HPP_
+#define MRS_LIB_UTILITY_SCOPE_CLEANUP_HPP_
+
+
+#include <functional>
+#include <utility>
+
+
+namespace mrs_lib
+{
+
+  /**
+   * @brief Utility class for running cleanup at the end of a scope.
+   */
+  template <typename T>
+  class ScopeCleanup
+  {
+  public:
+    /**
+     * @brief Create a scope cleanup that runs the specified callable when destroyed.
+     *
+     * @note The object must be stored in a variable, otherwise, it will be destroyed immediately.
+     */
+    explicit ScopeCleanup(T f) : cleanup_func_(std::move(f))
+    {
+    }
+
+    ~ScopeCleanup()
+    {
+      if (enabled_)
+      {
+        std::invoke(cleanup_func_);
+      }
+    }
+
+    ScopeCleanup(const ScopeCleanup&) = delete;
+    ScopeCleanup(ScopeCleanup&&) = delete;
+    ScopeCleanup& operator=(const ScopeCleanup&) = delete;
+    ScopeCleanup& operator=(ScopeCleanup&&) = delete;
+
+    /**
+     * @brief Disable running of the callback, when the cleanup object is destroyed.
+     */
+    void cancel()
+    {
+      enabled_ = false;
+    }
+
+  private:
+    T cleanup_func_;
+    bool enabled_ = true;
+  };
+
+} // namespace mrs_lib
+
+
+#endif // MRS_LIB_UTILITY_SCOPE_CLEANUP_HPP_

--- a/src/coro/cancellation.cpp
+++ b/src/coro/cancellation.cpp
@@ -26,7 +26,7 @@ namespace mrs_lib::coro
 
   } // namespace internal
 
-  internal::GetTaskStopTokenAwaiter get_task_stop_token()
+  internal::ImmediateAwaitable<internal::GetTaskStopTokenAwaiter> get_task_stop_token()
   {
     return {};
   }

--- a/src/coro/cancellation.cpp
+++ b/src/coro/cancellation.cpp
@@ -1,0 +1,34 @@
+#include "mrs_lib/coro/cancellation.hpp"
+
+namespace mrs_lib::coro
+{
+
+  namespace internal
+  {
+
+    bool GetTaskStopTokenAwaiter::await_ready()
+    {
+      return false;
+    }
+
+    bool GetTaskStopTokenAwaiter::await_suspend(CancellableContinuation continuation)
+    {
+      token_ = continuation.get_token();
+      continuation.release();
+      return false;
+    }
+
+    std::stop_token GetTaskStopTokenAwaiter::await_resume()
+    {
+      return std::move(token_);
+    }
+
+
+  } // namespace internal
+
+  internal::GetTaskStopTokenAwaiter get_task_stop_token()
+  {
+    return {};
+  }
+
+} // namespace mrs_lib::coro

--- a/src/coro/internal/thread_local_continuation_scheduler.cpp
+++ b/src/coro/internal/thread_local_continuation_scheduler.cpp
@@ -1,8 +1,9 @@
-#include <mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp>
+#include "mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
 
 #include <cassert>
 #include <coroutine>
 #include <cstddef>
+#include <deque>
 
 namespace mrs_lib::coro::internal
 {
@@ -18,6 +19,12 @@ namespace mrs_lib::coro::internal
       {
         auto&& scheduler = get_thread_local_scheduler_();
         scheduler.run_until_suspend_(handle);
+      }
+
+      static void resume_coroutine_soon(std::coroutine_handle<> handle)
+      {
+        auto&& scheduler = get_thread_local_scheduler_();
+        scheduler.run_soon_until_suspend_(handle);
       }
 
       static void schedule_coroutine_continuation(std::coroutine_handle<> handle)
@@ -49,20 +56,46 @@ namespace mrs_lib::coro::internal
         stored_id_++;
       }
 
-      void run_until_suspend_(std::coroutine_handle<> handle)
+      void run_queue_()
       {
         assert(!running);
         running = true;
-        set_continuation_(handle);
-        assert(released_id_ + 1 == stored_id_);
-        while (released_id_ != stored_id_)
+        while (coroutine_queue_.size() > 0)
         {
+          std::coroutine_handle<> handle = coroutine_queue_.front();
+          coroutine_queue_.pop_front();
+
+          set_continuation_(handle);
+
           assert(released_id_ + 1 == stored_id_);
-          released_id_++;
-          continuation_.resume();
+          while (released_id_ != stored_id_)
+          {
+            assert(released_id_ + 1 == stored_id_);
+            released_id_++;
+            continuation_.resume();
+          }
         }
         assert(running);
         running = false;
+      }
+
+      void run_until_suspend_(std::coroutine_handle<> handle)
+      {
+        assert(!running);
+        assert(coroutine_queue_.size() == 0);
+        coroutine_queue_.push_back(handle);
+        run_queue_();
+      }
+
+      void run_soon_until_suspend_(std::coroutine_handle<> handle)
+      {
+        if (!running)
+        {
+          run_until_suspend_(handle);
+        } else
+        {
+          coroutine_queue_.push_back(handle);
+        }
       }
 
       // Using unsigned ids that have defined overflow, removing the need to manually handle.
@@ -70,13 +103,15 @@ namespace mrs_lib::coro::internal
       size_t released_id_ = 0;
       bool running = false;
       std::coroutine_handle<> continuation_;
+
+      std::deque<std::coroutine_handle<>> coroutine_queue_;
     };
 
   } // namespace
 
-  void resume_coroutine(std::coroutine_handle<> handle)
+  void resume_coroutine_soon(std::coroutine_handle<> handle)
   {
-    ThreadLocalContinuationScheduler::resume_coroutine(handle);
+    ThreadLocalContinuationScheduler::resume_coroutine_soon(handle);
   }
 
   void schedule_coroutine_continuation(std::coroutine_handle<> handle)

--- a/src/coro/internal/thread_local_continuation_scheduler.cpp
+++ b/src/coro/internal/thread_local_continuation_scheduler.cpp
@@ -4,7 +4,7 @@
 #include <coroutine>
 #include <cstddef>
 
-namespace mrs_lib::internal
+namespace mrs_lib::coro::internal
 {
 
   namespace
@@ -85,4 +85,4 @@ namespace mrs_lib::internal
   }
 
 
-} // namespace mrs_lib::internal
+} // namespace mrs_lib::coro::internal

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,6 +7,21 @@ function(add_ros_isolated_launch_test path)
   add_launch_test("${path}" RUNNER "${RUNNER}" ${ARGN})
 endfunction()
 
+function(mrs_lib_add_simple_labeled_gtest label name file)
+  ament_add_gtest("${name}"
+    "${file}"
+    TIMEOUT 120
+  )
+  target_link_libraries("${name}"
+    mrs_lib::mrs_lib
+  )
+  set_property(
+    TEST "${name}"
+    APPEND PROPERTY
+    LABELS "${label}"
+  )
+endfunction()
+
 add_subdirectory(attitude_converter)
 add_subdirectory(batch_visualizer)
 add_subdirectory(coro)
@@ -36,4 +51,5 @@ add_subdirectory(timer_handler)
 add_subdirectory(transform_broadcaster)
 add_subdirectory(transformer)
 add_subdirectory(ukf)
+add_subdirectory(utility)
 add_subdirectory(utils)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -10,7 +10,6 @@ endfunction()
 function(mrs_lib_add_simple_labeled_gtest label name file)
   ament_add_gtest("${name}"
     "${file}"
-    TIMEOUT 120
   )
   target_link_libraries("${name}"
     mrs_lib::mrs_lib

--- a/test/coro/CMakeLists.txt
+++ b/test/coro/CMakeLists.txt
@@ -1,10 +1,2 @@
-get_filename_component(TEST_NAME "${CMAKE_CURRENT_SOURCE_DIR}" NAME)
-
-ament_add_gtest(test_${TEST_NAME}
-  test.cpp
-  TIMEOUT 120
-)
-
-target_link_libraries(test_${TEST_NAME}
-  mrs_lib::mrs_lib
-)
+mrs_lib_add_simple_labeled_gtest(coro test_coro_cancellation "cancellation_test.cpp")
+mrs_lib_add_simple_labeled_gtest(coro test_coro "coro_test.cpp")

--- a/test/coro/CMakeLists.txt
+++ b/test/coro/CMakeLists.txt
@@ -1,2 +1,7 @@
 mrs_lib_add_simple_labeled_gtest(coro test_coro_cancellation "cancellation_test.cpp")
 mrs_lib_add_simple_labeled_gtest(coro test_coro "coro_test.cpp")
+
+set_tests_properties(test_coro
+  PROPERTIES
+    TIMEOUT 300
+)

--- a/test/coro/cancellation_test.cpp
+++ b/test/coro/cancellation_test.cpp
@@ -1,0 +1,43 @@
+#include "mrs_lib/coro/cancellation.hpp"
+
+#include <gtest/gtest.h>
+
+#include "mrs_lib/coro/runners.hpp"
+#include "mrs_lib/coro/task.hpp"
+
+
+namespace
+{
+
+  mrs_lib::Task<> store_own_stop_token(std::stop_token& out_token, bool& finished)
+  {
+    out_token = co_await mrs_lib::coro::get_task_stop_token();
+    finished = true;
+  }
+
+  TEST(MrsLibCoroCancellation, StopTokenPassed)
+  {
+    bool finished = false;
+    std::stop_token out_token{};
+    std::stop_source stop_source{};
+
+    mrs_lib::coro::internal::start_task(stop_source.get_token(), &store_own_stop_token, std::ref(out_token), std::ref(finished));
+
+    ASSERT_TRUE(finished);
+    EXPECT_TRUE(out_token.stop_possible());
+    EXPECT_EQ(out_token, stop_source.get_token());
+  }
+
+  TEST(MrsLibCoroCancellation, StopTokenNotPassed)
+  {
+    bool finished = false;
+    std::stop_token out_token{};
+
+    mrs_lib::coro::internal::start_task(&store_own_stop_token, std::ref(out_token), std::ref(finished));
+
+    ASSERT_TRUE(finished);
+    EXPECT_FALSE(out_token.stop_possible());
+    EXPECT_EQ(out_token, std::stop_token{});
+  }
+
+} // namespace

--- a/test/coro/coro_test.cpp
+++ b/test/coro/coro_test.cpp
@@ -1,10 +1,14 @@
-#include <format>
-#include <memory>
+#include "mrs_lib/coro/task.hpp"
 
 #include <gtest/gtest.h>
 
-#include <mrs_lib/coro/runners.hpp>
-#include <mrs_lib/coro/task.hpp>
+#include <format>
+#include <memory>
+
+#include "mrs_lib/coro/runners.hpp"
+#include "mrs_lib/utility/scope_cleanup.hpp"
+#include "utility"
+
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
@@ -277,6 +281,77 @@ namespace
     co_return success;
   }
 
+  struct CancelOnAwait
+  {
+    bool await_ready()
+    {
+      return false;
+    }
+    template <typename T>
+    void await_suspend(std::coroutine_handle<T> handle)
+    {
+      // handle.destroy();
+      mrs_lib::coro::internal::CancellableContinuation(handle).cancel_and_destroy();
+    }
+    void await_resume()
+    {
+      assert(false);
+    }
+  };
+
+  mrs_lib::Task<void> cancel_in_depth(size_t depth)
+  {
+    if (depth == 0)
+    {
+      co_await CancelOnAwait();
+    } else
+    {
+      co_await cancel_in_depth(depth - 1);
+    }
+  }
+
+  class TokenPropagationTestAwaiter
+  {
+  public:
+    explicit TokenPropagationTestAwaiter(std::optional<std::stop_token>& stop_token) : stop_token_(&stop_token)
+    {
+    }
+
+    bool await_ready()
+    {
+      return false;
+    }
+    template <typename T>
+    bool await_suspend(std::coroutine_handle<T> handle)
+    {
+      using mrs_lib::coro::internal::CancellableContinuation;
+      EXPECT_FALSE(stop_token_->has_value());
+      auto continuation = CancellableContinuation(handle);
+      stop_token_->emplace(continuation.get_token());
+      // prevent the RAII type from destroying the continuation
+      continuation.release();
+      // Do not suspend
+      return false;
+    }
+    void await_resume()
+    {
+    }
+
+  private:
+    std::optional<std::stop_token>* stop_token_;
+  };
+
+  mrs_lib::Task<void> test_stop_token_propagation(TokenPropagationTestAwaiter awaiter, size_t depth)
+  {
+    if (depth == 0)
+    {
+      co_await awaiter;
+    } else
+    {
+      co_await test_stop_token_propagation(awaiter, depth - 1);
+    }
+  }
+
   TEST(MrsLibCoro, StartTaskArgsValueCategories)
   {
     // This test checks that start task compiles with all of these signatures.
@@ -540,6 +615,117 @@ namespace
     EXPECT_TRUE(finished);
   }
 
+  TEST(MrsLibCoro, DtorsRunWhenCancelled)
+  {
+    bool finished = false;
+
+    mrs_lib::coro::internal::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          mrs_lib::ScopeCleanup cleanup_set_finished([&finished]() { finished = true; });
+          co_await CancelOnAwait();
+          // This should be unreachable
+          EXPECT_TRUE(false);
+          cleanup_set_finished.cancel();
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  mrs_lib::Task<> test_dtor_order(size_t& idx, size_t depth)
+  {
+    mrs_lib::ScopeCleanup cleanup_check_order([&idx, depth] {
+      EXPECT_EQ(idx, depth);
+      idx++;
+    });
+    if (depth == 0)
+    {
+      co_await CancelOnAwait();
+    } else
+    {
+      co_await test_dtor_order(idx, depth - 1);
+    }
+  };
+
+  TEST(MrsLibCoro, DtorsOrderWhenCancelled)
+  {
+    bool finished = false;
+    const size_t depth = 5;
+    size_t index = 0;
+
+
+    mrs_lib::coro::internal::start_task(
+        [](bool& finished, size_t& index, size_t depth) -> mrs_lib::Task<> {
+          mrs_lib::ScopeCleanup cleanup_set_finished([&finished]() { finished = true; });
+          co_await test_dtor_order(index, depth);
+          // This should be unreachable
+          EXPECT_TRUE(false);
+          cleanup_set_finished.cancel();
+          co_return;
+        },
+        std::ref(finished), std::ref(index), depth);
+
+    EXPECT_TRUE(finished);
+    EXPECT_EQ(index, depth + 1);
+  }
+
+  TEST(MrsLibCoro, DtorsRunWhenCancelledDeeper)
+  {
+    bool finished = false;
+
+    mrs_lib::coro::internal::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          mrs_lib::ScopeCleanup cleanup_set_finished([&finished]() { finished = true; });
+          co_await cancel_in_depth(5);
+          // This should be unreachable
+          EXPECT_TRUE(false);
+          cleanup_set_finished.cancel();
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, DtorsNoStackOverflow)
+  {
+    bool finished = false;
+
+    mrs_lib::coro::internal::start_task(
+        [](bool& finished) -> mrs_lib::Task<> {
+          mrs_lib::ScopeCleanup cleanup_set_finished([&finished]() { finished = true; });
+          co_await cancel_in_depth(deep_recursion_depth);
+          // This should be unreachable
+          EXPECT_TRUE(false);
+          cleanup_set_finished.cancel();
+          co_return;
+        },
+        std::ref(finished));
+
+    EXPECT_TRUE(finished);
+  }
+
+  TEST(MrsLibCoro, StopTokenPropagates)
+  {
+    bool finished = false;
+
+    std::optional<std::stop_token> collected_stop_token_opt = std::nullopt;
+
+    std::stop_source stop_source{};
+    mrs_lib::coro::internal::start_task(
+        stop_source.get_token(),
+        [](bool& finished, TokenPropagationTestAwaiter awaiter) -> mrs_lib::Task<> {
+          co_await test_stop_token_propagation(awaiter, 10);
+          finished = true;
+          co_return;
+        },
+        std::ref(finished), TokenPropagationTestAwaiter(collected_stop_token_opt));
+
+    ASSERT_TRUE(finished);
+    ASSERT_TRUE(collected_stop_token_opt.has_value());
+    EXPECT_EQ(collected_stop_token_opt.value(), stop_source.get_token());
+  }
 
   //////////////////////////////////////////////////////////////////////////////
   // MrsLibCoroLoops                                                          //

--- a/test/coro/test.cpp
+++ b/test/coro/test.cpp
@@ -29,23 +29,24 @@ namespace
     };
   };
 
-  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<int>>().set_value(10)),
+  static_assert(noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<int>>().set_value(10)),
                 "ResultStorage::set_value should be noexcept when stored type is noexcept move constructible");
-  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<std::string>>().set_value(std::declval<std::string>())),
+  static_assert(noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<std::string>>().set_value(std::declval<std::string>())),
                 "ResultStorage::set_value should be noexcept when stored type is noexcept move constructible");
-  static_assert(!noexcept(std::declval<mrs_lib::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_value(std::declval<PotentiallyThrowingMoveOnly>())),
-                "ResultStorage::set_value should NOT be noexcept when stored type is NOT noexcept move constructible");
+  static_assert(
+      !noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_value(std::declval<PotentiallyThrowingMoveOnly>())),
+      "ResultStorage::set_value should NOT be noexcept when stored type is NOT noexcept move constructible");
 
-  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<int>>().set_exception(std::declval<std::exception_ptr>())),
+  static_assert(noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<int>>().set_exception(std::declval<std::exception_ptr>())),
                 "ResultStorage::set_exception should be noexcept");
-  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<std::string>>().set_exception(std::declval<std::exception_ptr>())),
+  static_assert(noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<std::string>>().set_exception(std::declval<std::exception_ptr>())),
                 "ResultStorage::set_exception should be noexcept");
-  static_assert(noexcept(std::declval<mrs_lib::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_exception(std::declval<std::exception_ptr>())),
+  static_assert(noexcept(std::declval<mrs_lib::coro::internal::ResultStorage<PotentiallyThrowingMoveOnly>>().set_exception(std::declval<std::exception_ptr>())),
                 "ResultStorage::set_exception should be noexcept");
 
   consteval bool result_storage_test_default_ctor_dtor()
   {
-    mrs_lib::internal::ResultStorage<int> storage;
+    mrs_lib::coro::internal::ResultStorage<int> storage;
 
     return true;
   }
@@ -53,7 +54,7 @@ namespace
 
   consteval bool result_storage_test_int()
   {
-    mrs_lib::internal::ResultStorage<int> storage;
+    mrs_lib::coro::internal::ResultStorage<int> storage;
     storage.set_value(10);
     assert(std::move(storage).get_value() == 10);
 
@@ -64,7 +65,7 @@ namespace
   consteval bool result_storage_test_string()
   {
     std::string s = "asdf";
-    mrs_lib::internal::ResultStorage<std::string> storage;
+    mrs_lib::coro::internal::ResultStorage<std::string> storage;
     storage.set_value(std::move(s));
     assert(std::move(storage).get_value() == "asdf");
 
@@ -283,19 +284,19 @@ namespace
     int lval_int = 42;
     std::unique_ptr<int> lval_uptr = std::make_unique<int>(42);
     // function reference
-    mrs_lib::internal::start_task(co_takes_val, 42);
-    mrs_lib::internal::start_task(co_takes_lval_ref, std::ref(lval_int));
-    mrs_lib::internal::start_task(co_takes_rval_ref, 42);
-    mrs_lib::internal::start_task(co_takes_move_only, std::make_unique<int>(42));
-    mrs_lib::internal::start_task(co_takes_move_only_lval_ref, std::ref(lval_uptr));
-    mrs_lib::internal::start_task(co_takes_move_only_rval_ref, std::make_unique<int>(42));
+    mrs_lib::coro::internal::start_task(co_takes_val, 42);
+    mrs_lib::coro::internal::start_task(co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::coro::internal::start_task(co_takes_rval_ref, 42);
+    mrs_lib::coro::internal::start_task(co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::coro::internal::start_task(co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::coro::internal::start_task(co_takes_move_only_rval_ref, std::make_unique<int>(42));
     // function pointer
-    mrs_lib::internal::start_task(&co_takes_val, 42);
-    mrs_lib::internal::start_task(&co_takes_lval_ref, std::ref(lval_int));
-    mrs_lib::internal::start_task(&co_takes_rval_ref, 42);
-    mrs_lib::internal::start_task(&co_takes_move_only, std::make_unique<int>(42));
-    mrs_lib::internal::start_task(&co_takes_move_only_lval_ref, std::ref(lval_uptr));
-    mrs_lib::internal::start_task(&co_takes_move_only_rval_ref, std::make_unique<int>(42));
+    mrs_lib::coro::internal::start_task(&co_takes_val, 42);
+    mrs_lib::coro::internal::start_task(&co_takes_lval_ref, std::ref(lval_int));
+    mrs_lib::coro::internal::start_task(&co_takes_rval_ref, 42);
+    mrs_lib::coro::internal::start_task(&co_takes_move_only, std::make_unique<int>(42));
+    mrs_lib::coro::internal::start_task(&co_takes_move_only_lval_ref, std::ref(lval_uptr));
+    mrs_lib::coro::internal::start_task(&co_takes_move_only_rval_ref, std::make_unique<int>(42));
   }
 
   TEST(MrsLibCoro, StartCopyDecays)
@@ -317,12 +318,12 @@ namespace
     int val = 0;
 
     // This call should copy the value and invoke the `int &&` overload
-    mrs_lib::internal::start_task(Func{}, val);
+    mrs_lib::coro::internal::start_task(Func{}, val);
 
     EXPECT_EQ(val, 0);
 
     // The reference wrapper should be able to keep the reference and call the `int&` overload
-    mrs_lib::internal::start_task(Func{}, std::ref(val));
+    mrs_lib::coro::internal::start_task(Func{}, std::ref(val));
 
     EXPECT_EQ(val, 42);
   }
@@ -331,7 +332,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           finished = true;
           co_return;
@@ -346,7 +347,7 @@ namespace
     int result = 0;
 
     // No ampersand in front of function name - passing function reference
-    mrs_lib::internal::start_task(co_set_42, std::ref(result));
+    mrs_lib::coro::internal::start_task(co_set_42, std::ref(result));
 
     EXPECT_EQ(result, 42);
   }
@@ -356,7 +357,7 @@ namespace
     int result = 0;
 
     // Ampersand in front of function name - passing function pointer
-    mrs_lib::internal::start_task(&co_set_42, std::ref(result));
+    mrs_lib::coro::internal::start_task(&co_set_42, std::ref(result));
 
     EXPECT_EQ(result, 42);
   }
@@ -377,7 +378,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_42();
           EXPECT_EQ(val, 42);
@@ -393,7 +394,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           std::unique_ptr<int> val = co_await co_uptr_42();
           EXPECT_EQ(*val, 42);
@@ -409,7 +410,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_2_times_42();
           EXPECT_EQ(val, 84);
@@ -425,7 +426,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           int val = co_await co_42_recursive(deep_recursion_depth);
           EXPECT_EQ(val, 42);
@@ -441,7 +442,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_throws_logic_error);
           EXPECT_TRUE(val);
@@ -459,7 +460,7 @@ namespace
     {
       bool finished = false;
 
-      mrs_lib::internal::start_task(
+      mrs_lib::coro::internal::start_task(
           [](bool& finished, size_t level) -> mrs_lib::Task<> {
             bool val = co_await co_check_throws(co_call_throwning, level);
             EXPECT_TRUE(val);
@@ -476,7 +477,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_throws_logic_error_non_void);
           EXPECT_TRUE(val);
@@ -494,7 +495,7 @@ namespace
     {
       bool finished = false;
 
-      mrs_lib::internal::start_task(
+      mrs_lib::coro::internal::start_task(
           [](bool& finished, size_t level) -> mrs_lib::Task<> {
             bool val = co_await co_check_throws(co_call_throwning_non_void, level);
             EXPECT_TRUE(val);
@@ -511,7 +512,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await co_check_throws(co_get_error_on_move);
           EXPECT_TRUE(val);
@@ -527,7 +528,7 @@ namespace
   {
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished) -> mrs_lib::Task<> {
           bool val = co_await check_get_exception_ptr();
           EXPECT_TRUE(val);
@@ -576,7 +577,7 @@ namespace
 
     bool finished = false;
 
-    mrs_lib::internal::start_task(
+    mrs_lib::coro::internal::start_task(
         [](bool& finished, size_t iterations) -> mrs_lib::Task<> {
           size_t val = co_await co_test_long_loop(iterations);
           EXPECT_EQ(val, iterations);

--- a/test/service_client_handler/test.cpp
+++ b/test/service_client_handler/test.cpp
@@ -294,7 +294,7 @@ TEST_F(Test, CoroCall)
     despin();
   };
 
-  tim = node_->create_timer(0s, [test_fun]() -> void { mrs_lib::internal::start_task(test_fun); }, callback_group_);
+  tim = node_->create_timer(0s, [test_fun]() -> void { mrs_lib::coro::internal::start_task(test_fun); }, callback_group_);
   executor_->spin();
 
   ASSERT_TRUE(completed);

--- a/test/utility/CMakeLists.txt
+++ b/test/utility/CMakeLists.txt
@@ -1,0 +1,1 @@
+mrs_lib_add_simple_labeled_gtest(utility scope_cleanup "scope_cleanup_test.cpp")

--- a/test/utility/scope_cleanup_test.cpp
+++ b/test/utility/scope_cleanup_test.cpp
@@ -1,0 +1,35 @@
+#include "mrs_lib/utility/scope_cleanup.hpp"
+
+#include <gtest/gtest.h>
+
+
+namespace
+{
+
+  TEST(MrsLibUtilityScopeCleanup, RunsWhenDestroyed)
+  {
+    bool triggered = false;
+    {
+      mrs_lib::ScopeCleanup cleanup_set_triggered([&] { triggered = true; });
+
+      EXPECT_FALSE(triggered);
+    }
+
+    EXPECT_TRUE(triggered);
+  }
+
+  TEST(MrsLibUtilityScopeCleanup, DoesNotRunWhenCanceled)
+  {
+    bool triggered = false;
+    {
+      mrs_lib::ScopeCleanup cleanup_set_triggered([&] { triggered = true; });
+
+      EXPECT_FALSE(triggered);
+
+      cleanup_set_triggered.cancel();
+    }
+
+    EXPECT_FALSE(triggered);
+  }
+
+} // namespace


### PR DESCRIPTION
Stacked on top of https://github.com/ctu-mrs/mrs_lib/pull/104. Please merge that one first.

### Description

- refactor: moved coroutines to `mrs_lib::coro` namespace
  - mrs_lib::Task is exporting with `using` directive since it will likely be used much more than any other coroutine code
- refactor: moved `ResultStorage` to separate file
- feat: add queue to thread local continuation scheduler
  - this allows starting coroutines from other coroutines (used in some WIP utility functions)
- feat: added `ScopeCleanup` utility class for running any code at the end of its lifetime
- feat: added better cancellation for coroutines
  - start_task can be given a stop_token to cancel the coroutine
  - awaitables can use this to wake up and cancel suspended tasks
    - this was not yet implemented in the `ServiceAwaitable`