### PR TITLE
Remove clang coro annotations from `Task`

### DIFF
--- a/include/mrs_lib/coro/internal/attributes.hpp
+++ b/include/mrs_lib/coro/internal/attributes.hpp
@@ -1,6 +1,8 @@
 #ifndef MRS_LIB_CORO_INTERNAL_ATTRIBUTES_HPP_
 #define MRS_LIB_CORO_INTERNAL_ATTRIBUTES_HPP_
 
+// These annotations are currently not used, because they do not allow using
+// std::invoke to call coroutines.
 #ifdef __clang__
 #define MRS_LIB_INTERNAL_CORO_RETURN_TYPE [[clang::coro_return_type]]
 #define MRS_LIB_INTERNAL_CORO_WRAPPER [[clang::coro_wrapper]]

--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -296,7 +296,7 @@ namespace mrs_lib
    */
   template <typename T>
     requires(std::same_as<T, std::remove_cvref_t<T>>)
-  class [[nodiscard("Task is lazy and does not run until `co_await`ed.")]] MRS_LIB_INTERNAL_CORO_RETURN_TYPE MRS_LIB_INTERNAL_CORO_LIFETIMEBOUND Task
+  class [[nodiscard("Task is lazy and does not run until `co_await`ed.")]] Task
   {
   public:
     using promise_type = internal::PromiseType<T>;


### PR DESCRIPTION
These annotations can help find errors in coroutine code, however, they do not allow using std::invoke on coroutines. This caused compilation errors on clang.