### PR TITLE
Add compilation tests for `mrs_lib::coro::Task`

### DIFF
--- a/include/mrs_lib/coro/task.hpp
+++ b/include/mrs_lib/coro/task.hpp
@@ -237,6 +237,11 @@ namespace mrs_lib::coro
       TaskAwaitable(TaskAwaitable&&) = delete;
       TaskAwaitable& operator=(TaskAwaitable&&) = delete;
 
+      // This type should only be awaitable when directly returned from the
+      // co_await operator of Task. This prevents it from being awaitable when
+      // not returned from co_await operator.
+      void operator co_await() const = delete;
+
     private:
       TaskAwaitable(std::coroutine_handle<Promise> task_handle) : task_handle_(task_handle)
       {

--- a/test/coro/CMakeLists.txt
+++ b/test/coro/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(compilation_tests)
+
 mrs_lib_add_simple_labeled_gtest(coro test_coro_cancellation "cancellation_test.cpp")
 mrs_lib_add_simple_labeled_gtest(coro test_coro "coro_test.cpp")
 

--- a/test/coro/compilation_tests/CMakeLists.txt
+++ b/test/coro/compilation_tests/CMakeLists.txt
@@ -1,0 +1,45 @@
+function(mrs_lib_add_compilation_test label target file)
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
+  if(TARGET "${target}")
+    message(FATAL_ERROR "Target: '${target}' already exists.")
+  endif()
+
+  add_library("${target}" STATIC)
+  set_target_properties("${target}"
+    PROPERTIES
+      EXCLUDE_FROM_ALL ON
+      EXCLUDE_FROM_DEFAULT_BUILD ON
+  )
+  target_sources("${target}"
+    PRIVATE
+      "${file}"
+  )
+  target_link_libraries("${target}"
+    PRIVATE
+      mrs_lib::mrs_lib
+  )
+
+  ament_add_test("${target}"
+    GENERATE_RESULT_FOR_RETURN_CODE_ZERO
+    COMMAND
+      $<TARGET_FILE:Python3::Interpreter>
+      "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/runner.py"
+      --cmake-command "${CMAKE_COMMAND}"
+      --target "${target}"
+      --source "${CMAKE_CURRENT_LIST_DIR}/${file}"
+    TIMEOUT "${timeout}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+  )
+
+  set_property(TEST "${target}"
+    APPEND PROPERTY LABELS "${label}"
+  )
+endfunction()
+
+mrs_lib_add_compilation_test("coro;coro_compile" test_compile_task_await_after_manual_op_lvalue "task_await_after_manual_op_lvalue.cpp")
+mrs_lib_add_compilation_test("coro;coro_compile" test_compile_task_await_after_manual_op_xvalue "task_await_after_manual_op_xvalue.cpp")
+
+mrs_lib_add_compilation_test("coro;coro_compile" test_compile_task_await_lvalue "task_await_lvalue.cpp")
+mrs_lib_add_compilation_test("coro;coro_compile" test_compile_task_await_prvalue "task_await_prvalue.cpp")
+mrs_lib_add_compilation_test("coro;coro_compile" test_compile_task_await_xvalue "task_await_xvalue.cpp")

--- a/test/coro/compilation_tests/runner.py
+++ b/test/coro/compilation_tests/runner.py
@@ -1,0 +1,137 @@
+import argparse
+import dataclasses
+import json
+import re
+import subprocess
+from pathlib import Path
+
+START_LINE = "// RUNNER HEADER START"
+END_LINE = "// RUNNER HEADER END"
+
+OUTPUT_LINE_LEN = 60
+
+
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class TestDescription:
+    should_succeed: bool
+    expected_diagnostics: list[re.Pattern]
+
+
+def shallow_checked_cast[T](type: type[T], val: object) -> T:
+    if not isinstance(val, type):
+        raise TypeError
+    return val
+
+
+def parse_source(source_path: Path) -> TestDescription:
+    with open(source_path, "r") as file:
+        file_lines = file.read().splitlines()
+    header_start_line = None
+    for i, line in enumerate(file_lines):
+        if line == START_LINE:
+            header_start_line = i
+            break
+    if header_start_line is None:
+        raise ValueError("Could not find header start.")
+    data_lines = []
+    for line in file_lines[header_start_line + 1 :]:
+        if not line.startswith("//"):
+            raise ValueError(
+                f"Expected line to start with '//', found: '{line}'"
+            )
+        if line == END_LINE:
+            break
+        data_lines.append(line.removeprefix("//").strip())
+    data = json.loads("\n".join(data_lines))
+    patterns = [
+        re.compile(shallow_checked_cast(str, pattern))
+        for pattern in data["expected_diagnostics"]
+    ]
+
+    return TestDescription(
+        should_succeed=shallow_checked_cast(bool, data["should_succeed"]),
+        expected_diagnostics=patterns,
+    )
+
+
+def check_description(description: TestDescription) -> None:
+    if description.should_succeed and len(description.expected_diagnostics) > 0:
+        raise ValueError(
+            "Expected diagnostics should not be used when the test is expected to succeed.\n"
+            "It may already be compiled and thus the diagnostic won't be shown again."
+        )
+    if (
+        not description.should_succeed
+        and len(description.expected_diagnostics) == 0
+    ):
+        print(
+            "Warning: Test expected to fail but no expected diagnostics provided.\n"
+            "  This is not recommended because it may fail for different reason than you want."
+        )
+
+
+def print_compiler_output(result: subprocess.CompletedProcess[bytes]) -> None:
+    msg = "Compiler stdout:"
+    print(msg, "-" * (OUTPUT_LINE_LEN - 1 - len(msg)))
+    print(result.stdout.decode())
+    msg = "Compiler stderr:"
+    print(msg, "-" * (OUTPUT_LINE_LEN - 1 - len(msg)))
+    print(result.stderr.decode())
+    print("-" * (OUTPUT_LINE_LEN - len(msg)))
+
+
+def run_test(
+    cmake_command: str,
+    target: str,
+    description: TestDescription,
+) -> bool:
+    result = subprocess.run(
+        [cmake_command, "--build", ".", "--target", target], capture_output=True
+    )
+    print_compiler_output(result)
+    failed = result.returncode == 0
+    if failed != description.should_succeed:
+        print(
+            "FAIL: Result not expected:\n"
+            f"  Should fail: {description.should_succeed}\n"
+            f"  Exit code: {result.returncode}"
+        )
+        return False
+    decoded_stdout = result.stdout.decode()
+    decoded_stderr = result.stderr.decode()
+    output = f"{decoded_stdout}\n{decoded_stderr}"
+    patterns_ok = True
+    for pattern in description.expected_diagnostics:
+        found = pattern.search(output)
+        if found is None:
+            print(
+                "FAIL: Pattern not matched\n"
+                f"Output does not match this pattern: {pattern}"
+            )
+            patterns_ok = False
+    return patterns_ok
+
+
+def print_result(is_success: bool) -> None:
+    if is_success:
+        print(f"{" SUCCESS ":=^{OUTPUT_LINE_LEN}}")
+    else:
+        print(f"{" FAILURE ":=^{OUTPUT_LINE_LEN}}")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--cmake-command", type=str, required=True)
+    parser.add_argument("--target", type=str, required=True)
+    parser.add_argument("--source", type=Path, required=True)
+    args = parser.parse_args()
+
+    description = parse_source(args.source)
+    check_description(description)
+    is_success = run_test(args.cmake_command, args.target, description)
+    print_result(is_success)
+    exit(0 if is_success else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/coro/compilation_tests/task_await_after_manual_op_lvalue.cpp
+++ b/test/coro/compilation_tests/task_await_after_manual_op_lvalue.cpp
@@ -1,0 +1,24 @@
+// RUNNER HEADER START
+// {
+//   "should_succeed": false,
+//   "expected_diagnostics": [
+//     "delete",
+//     "// This line should cause error."
+//   ]
+// }
+// RUNNER HEADER END
+
+
+#include "mrs_lib/coro/task.hpp"
+
+mrs_lib::Task<int> co_get_int(const int& val)
+{
+  co_return val * 2;
+}
+
+mrs_lib::Task<void> test()
+{
+  // This code should not compile as it leads to dangling reference.
+  auto task = operator co_await(co_get_int(21));
+  co_await task; // This line should cause error.
+}

--- a/test/coro/compilation_tests/task_await_after_manual_op_xvalue.cpp
+++ b/test/coro/compilation_tests/task_await_after_manual_op_xvalue.cpp
@@ -1,0 +1,24 @@
+// RUNNER HEADER START
+// {
+//   "should_succeed": false,
+//   "expected_diagnostics": [
+//     "delete",
+//     "// This line should cause error."
+//   ]
+// }
+// RUNNER HEADER END
+
+
+#include "mrs_lib/coro/task.hpp"
+
+mrs_lib::Task<int> co_get_int(const int& val)
+{
+  co_return val * 2;
+}
+
+mrs_lib::Task<void> test()
+{
+  // This code should not compile as it leads to dangling reference.
+  auto task = operator co_await(co_get_int(21));
+  co_await std::move(task); // This line should cause error.
+}

--- a/test/coro/compilation_tests/task_await_lvalue.cpp
+++ b/test/coro/compilation_tests/task_await_lvalue.cpp
@@ -1,0 +1,24 @@
+// RUNNER HEADER START
+// {
+//   "should_succeed": false,
+//   "expected_diagnostics": [
+//     "delete",
+//     "// This line should cause error."
+//   ]
+// }
+// RUNNER HEADER END
+
+
+#include "mrs_lib/coro/task.hpp"
+
+mrs_lib::Task<int> co_get_int(const int& val)
+{
+  co_return val * 2;
+}
+
+mrs_lib::Task<void> test()
+{
+  // This code should not compile as it leads to dangling reference.
+  auto task = co_get_int(21);
+  co_await task; // This line should cause error.
+}

--- a/test/coro/compilation_tests/task_await_prvalue.cpp
+++ b/test/coro/compilation_tests/task_await_prvalue.cpp
@@ -1,0 +1,20 @@
+// RUNNER HEADER START
+// {
+//   "should_succeed": true,
+//   "expected_diagnostics": [
+//   ]
+// }
+// RUNNER HEADER END
+
+
+#include "mrs_lib/coro/task.hpp"
+
+mrs_lib::Task<int> co_get_int(const int& val)
+{
+  co_return val * 2;
+}
+
+mrs_lib::Task<void> test()
+{
+  co_await co_get_int(21); // This line should not cause any errors.
+}

--- a/test/coro/compilation_tests/task_await_xvalue.cpp
+++ b/test/coro/compilation_tests/task_await_xvalue.cpp
@@ -1,0 +1,24 @@
+// RUNNER HEADER START
+// {
+//   "should_succeed": false,
+//   "expected_diagnostics": [
+//     "delete",
+//     "// This line should cause error."
+//   ]
+// }
+// RUNNER HEADER END
+
+
+#include "mrs_lib/coro/task.hpp"
+
+mrs_lib::Task<int> co_get_int(const int& val)
+{
+  co_return val * 2;
+}
+
+mrs_lib::Task<void> test()
+{
+  // This code should not compile as it leads to dangling reference.
+  auto task = co_get_int(21);
+  co_await std::move(task); // This line should cause error.
+}

--- a/test/coro/coro_test.cpp
+++ b/test/coro/coro_test.cpp
@@ -77,6 +77,28 @@ namespace
   }
   static_assert(result_storage_test_string());
 
+  template <typename T>
+  T declval2()
+  {
+    static_assert(false, "Only for unevaluated contexts.");
+  }
+
+  template <typename T>
+  concept CanBeNonMemberCoAwaited = requires() { operator co_await(declval2<T>()); };
+
+  template <typename T>
+  concept CanBeMemberCoAwaited = requires() { declval2<T>().operator co_await(); };
+
+  template <typename T>
+  concept CanBeOperatorCoAwaited = CanBeNonMemberCoAwaited<T> || CanBeMemberCoAwaited<T>;
+
+  // Test that only prvalue of task can be co-awaited. This helps ensure that
+  // references passed to the arguments of the task are valid for the whole
+  // lifetime of the called task, even if they are bound to temporaries.
+  static_assert(CanBeOperatorCoAwaited<mrs_lib::Task<void>>, "prvalue of task can be co-awaited.");
+  static_assert(!CanBeOperatorCoAwaited<mrs_lib::Task<void>&&>, "xvalue of task cannot be co-awaited.");
+  static_assert(!CanBeOperatorCoAwaited<mrs_lib::Task<void>&>, "lvalue of task cannot be co-awaited.");
+
 } // namespace
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
The `Task` class is designed in such a way that coroutines should be safe to use with reference parameters. This is enforced by strict rules on awaiting the Tasks - they can only be awaited in the same expression in which they were created. This is enforced by compile time checks.

This commit adds tests that check the compilation fails when it is supposed to. This is done by compiling incorrect program and matching the compiler output against regular expressions of expected diagnostics.