### PR TITLE
Add coro Event, update awaitable service client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ target_sources(mrs_lib_mrs_lib
     "src/batch_visualizer/visual_object.cpp"
     # src/coro
     "src/coro/cancellation.cpp"
+    "src/coro/event.cpp"
     # src/coro/internal
     "src/coro/internal/thread_local_continuation_scheduler.cpp"
     # src/dynparam_mgr
@@ -165,6 +166,7 @@ target_sources(mrs_lib_mrs_lib
     "include/mrs_lib/visual_object.h"
     # include/mrs_lib/coro
     "include/mrs_lib/coro/cancellation.hpp"
+    "include/mrs_lib/coro/event.hpp"
     "include/mrs_lib/coro/runners.hpp"
     "include/mrs_lib/coro/task.hpp"
     "include/mrs_lib/coro/task.impl.hpp"

--- a/include/mrs_lib/coro/event.hpp
+++ b/include/mrs_lib/coro/event.hpp
@@ -1,0 +1,290 @@
+#ifndef MRS_LIB_CORO_EVENT_HPP_
+#define MRS_LIB_CORO_EVENT_HPP_
+
+
+#include <memory>
+#include <coroutine>
+#include <mutex>
+#include <cassert>
+#include <optional>
+#include <utility>
+
+#include "mrs_lib/coro/internal/continuation.hpp"
+#include "mrs_lib/coro/internal/immediate_awaitable.hpp"
+
+
+namespace mrs_lib::coro
+{
+
+  class Event;
+  class EventAwaitable;
+
+  /**
+   * @brief Create Event and its bound awaitable.
+   *
+   * Together, the Event and EventAwaitable form a onedirectional oneshot
+   * communication channel.
+   *
+   * @see mrs_lib::coro::Event
+   * @see mrs_lib::coro::EventAwaitable
+   */
+  std::pair<Event, EventAwaitable> make_event();
+
+  /**
+   * @brief Exception thrown on incorrect use of Event/EventAwaitable.
+   */
+  class EventError : std::logic_error
+  {
+  public:
+    enum class Type
+    {
+      empty_awaitable_state,
+    };
+
+    EventError(Type type);
+
+  private:
+    static const char* get_msg(Type type);
+
+    Type type_;
+  };
+
+  namespace internal
+  {
+
+    /**
+     * @brief Internal class for handling events.
+     */
+    class EventState
+    {
+    private:
+      enum class Status
+      {
+        unset,
+        set,
+        cancelled,
+      };
+
+      /**
+       * @brief Callable used in stop_callback to cancel the wait.
+       */
+      struct StopCallbackCallable
+      {
+        EventState* event_state;
+
+        void operator()();
+      };
+
+    public:
+      /**
+       * @brief Try triggering the event state.
+       * @return true if succeeded, false otherwise
+       *
+       * The call will fail (return false) if the event was already triggered or cancelled.
+       */
+      bool try_trigger();
+
+      /**
+       * @brief Try cancelling the event state.
+       * @return true if succeeded, false otherwise
+       *
+       * The call will fail (return false) if the event was already triggered or cancelled.
+       */
+      bool try_cancel();
+
+      /**
+       * @brief Store or resume the continuation as target for this event.
+       *
+       * @param continuation Continuation to use for the event.
+       * @param token_cancelable Whether to respect the stop token of the continuation.
+       * @param callback Callback to run when the coroutine suspends.
+       * @return value to return from await_suspend
+       *
+       * If the state was not yet triggered nor cancelled, the continuation is
+       * stored and resumed/canceled when the respective event comes.
+       * The @p callback is called only in this case.
+       *
+       * If the event was already triggered, it will return to not suspend.
+       *
+       * If the event was already cancelled, the continuation will be cancelled immediately.
+       */
+      bool add_continuation(CancellableContinuation continuation, bool token_cancelable, std::function<void()> callback);
+
+      /**
+       * @brief Check if the event was already triggered.
+       *
+       * @return true if event was already triggered, false otherwise.
+       *
+       * @note If the event was cancelled, this will return false.
+       */
+      bool is_ready();
+
+    private:
+      std::mutex mutex_{};
+      Status status_ = Status::unset;
+      internal::CancellableContinuation continuation_{};
+
+      std::optional<std::stop_callback<StopCallbackCallable>> stop_callback_{};
+    };
+
+    /**
+     * @brief Internal awaitable used to wait for events.
+     *
+     * This should likely not be used outside of coroutine library functions.
+     */
+    class LowLevelEventAwaitable
+    {
+    public:
+      class [[nodiscard]] Awaiter
+      {
+      public:
+        explicit Awaiter(std::shared_ptr<internal::EventState> state, bool token_cancellable, std::function<void()> callback);
+
+        bool await_ready();
+        template <typename T>
+        bool await_suspend(std::coroutine_handle<T> handle)
+        {
+          return await_suspend(CancellableContinuation(handle));
+        }
+        bool await_suspend(CancellableContinuation continuation);
+        void await_resume();
+
+      private:
+        std::shared_ptr<internal::EventState> state_;
+        bool is_token_cancellable_ = true;
+        std::function<void()> callback_;
+      };
+
+      enum class StopTokenBehavior
+      {
+        respect,
+        ignore,
+      };
+
+
+      ~LowLevelEventAwaitable() = default;
+
+      LowLevelEventAwaitable(const LowLevelEventAwaitable&) = delete;
+      LowLevelEventAwaitable& operator=(const LowLevelEventAwaitable&) = delete;
+      LowLevelEventAwaitable(LowLevelEventAwaitable&& other) noexcept;
+      LowLevelEventAwaitable& operator=(LowLevelEventAwaitable&& other) noexcept;
+
+      /**
+       * @brief Create awaitable for this event with default configuration.
+       */
+      ImmediateAwaitable<Awaiter> get_awaitable() &&;
+
+      /**
+       * @brief Create awaitable for this event.
+       *
+       * @param stop_token_behavior Whether to respect stop token request to cancel the await.
+       * @param callback Callback to run during suspend.
+       *
+       * The callback is only run if the coroutine is suspended.
+       *
+       * The callback can be used to register a waker that will start the coroutine once ready.
+       *
+       * @warning The passed function should not reference local state of the
+       * coroutine as it may be destroyed during the callback execution.
+       */
+      ImmediateAwaitable<Awaiter> get_awaitable(StopTokenBehavior stop_token_behavior, std::function<void()> callback) &&;
+
+    private:
+      explicit LowLevelEventAwaitable(std::shared_ptr<internal::EventState> state);
+
+      std::shared_ptr<internal::EventState> state_;
+
+      friend std::pair<Event, EventAwaitable> mrs_lib::coro::make_event();
+    };
+
+    /**
+     * @brief Get LowLevelEventAwaitable from EventAwaitable.
+     */
+    LowLevelEventAwaitable get_low_level_event_awaitable(EventAwaitable event_awaitable);
+
+  } // namespace internal
+
+  /**
+   * @brief Event that can be used to trigger coroutines.
+   *
+   * This is the write part of a onedirectional oneshot communication channel.
+   * To create the pair, use mrs_lib::coro::make_event.
+   *
+   * @see mrs_lib::coro::make_event
+   * @see mrs_lib::coro::EventAwaitable
+   */
+  class Event
+  {
+  public:
+    ~Event();
+
+    Event(const Event&) = delete;
+    Event& operator=(const Event&) = delete;
+
+    Event(Event&& other) noexcept;
+    Event& operator=(Event&& other) noexcept;
+
+    /**
+     * @brief Try triggering the event.
+     * @return true if succeeded, false otherwise
+     *
+     * The call will fail (return false) if the event was already triggered or cancelled.
+     */
+    bool try_trigger();
+
+    /**
+     * @brief Try cancelling the event.
+     * @return true if succeeded, false otherwise
+     *
+     * The call will fail (return false) if the event was already triggered or cancelled.
+     */
+    bool try_cancel();
+
+  private:
+    explicit Event(std::shared_ptr<internal::EventState> state);
+
+    std::shared_ptr<internal::EventState> state_;
+
+    friend std::pair<Event, EventAwaitable> make_event();
+  };
+
+  /**
+   * @brief Event awaitable that can be awaited by coroutines, resuming them once triggered.
+   *
+   * This is the read part of a onedirectional oneshot communication channel.
+   * To create the pair, use mrs_lib::coro::make_event.
+   *
+   * @see mrs_lib::coro::make_event
+   * @see mrs_lib::coro::Event
+   */
+  class EventAwaitable
+  {
+  public:
+    /**
+     * @brief Create EventAwaitable from a low level awaitable.
+     *
+     * This function should not be used in user code.
+     * Instead, use mrs_lib::coro::make_event.
+     */
+    explicit EventAwaitable(internal::LowLevelEventAwaitable internal_awaitable);
+
+    /**
+     * @brief Wait for the event to trigger / cancel.
+     *
+     * Result of this function must be awaited.
+     *
+     * @note Every event can only be awaited once.
+     * To help enforce that behavior, this method is rvalue qualified.
+     * As a result, this must be awaited as rvalue (eg. using `co_await std::move(awaiter).wait()`).
+     */
+    auto wait() && -> internal::ImmediateAwaitable<internal::LowLevelEventAwaitable::Awaiter>;
+
+  private:
+    internal::LowLevelEventAwaitable internal_awaitable_;
+
+    friend internal::LowLevelEventAwaitable internal::get_low_level_event_awaitable(EventAwaitable event_awaitable);
+  };
+
+} // namespace mrs_lib::coro
+
+#endif // MRS_LIB_CORO_EVENT_HPP_

--- a/include/mrs_lib/impl/service_client_handler.hpp
+++ b/include/mrs_lib/impl/service_client_handler.hpp
@@ -5,171 +5,12 @@
  */
 #pragma once
 
+#include <mrs_lib/coro/cancellation.hpp>
+#include <mrs_lib/coro/event.hpp>
 #include <mrs_lib/service_client_handler.h>
 
 namespace mrs_lib
 {
-
-  namespace internal
-  {
-
-    template <typename ServiceType>
-      requires(rosidl_generator_traits::is_service<ServiceType>::value)
-    class [[nodiscard("This service call is only performed when `co_await`ed.")]] ServiceAwaitable
-    {
-      using Client = rclcpp::Client<ServiceType>;
-      using Response = ServiceType::Response;
-      using Request = ServiceType::Request;
-
-    public:
-      ServiceAwaitable(const ServiceAwaitable&) = delete;
-      ServiceAwaitable& operator=(const ServiceAwaitable&) = delete;
-      ServiceAwaitable(ServiceAwaitable&&) = delete;
-      ServiceAwaitable& operator=(ServiceAwaitable&&) = delete;
-
-      bool await_ready()
-      {
-        return false;
-      }
-
-      bool await_suspend(std::coroutine_handle<> continuation)
-      {
-        // Store the continuation into the awaitable.
-        // It will either be invoked when the service completes or destroyed if it is cancelled.
-        data_.continuation = continuation;
-        std::shared_ptr<Client> client = data_.client.lock();
-        if (client == nullptr || !client->service_is_ready())
-        {
-          data_.response = std::nullopt;
-          // Do not suspend
-          return false;
-        }
-        client->async_send_request(data_.request,
-                                   std::function([data_handle = DataHandle(data_)](std::shared_future<std::shared_ptr<Response>> future) mutable {
-                                     auto data = data_handle.leak();
-                                     data->response = future.get();
-                                     (*data).response = future.get();
-                                     auto continuation = std::exchange(data->continuation, nullptr);
-                                     coro::internal::resume_coroutine_soon(continuation);
-                                   }));
-        return true;
-      }
-
-      std::optional<std::shared_ptr<Response>> await_resume()
-      {
-        return data_.response;
-      }
-
-    private:
-      ServiceAwaitable(std::weak_ptr<Client> client, std::shared_ptr<Request> request)
-          : data_{
-                .client = std::move(client),
-                .request = std::move(request),
-            }
-      {
-      }
-
-      struct Data
-      {
-        std::weak_ptr<Client> client;
-        std::shared_ptr<Request> request;
-        std::optional<std::shared_ptr<Response>> response = std::nullopt;
-        std::coroutine_handle<> continuation = nullptr;
-        // Intrusive ref counting - used to destroy continuation in case of cancellation
-        std::atomic<size_t> ref_count = 0;
-      };
-
-      class DataHandle
-      {
-      public:
-        DataHandle(Data& data) : data_(&data)
-        {
-          size_t prev_ref_count = data_->ref_count.fetch_add(1);
-          // This constructor is called when awaiting the result.
-          // We do not allow multiple awaits, thus, this should always be zero.
-          assert(prev_ref_count == 0);
-        }
-
-        DataHandle(const DataHandle& other) : data_(other.data_)
-        {
-          data_->ref_count++;
-        }
-
-        DataHandle& operator=(const DataHandle& other)
-        {
-          decrement_ref_count_();
-          data_ = other.data_;
-          return *this;
-        }
-
-        DataHandle(DataHandle&& other) : data_(other.data_)
-        {
-          data_->ref_count++;
-        }
-
-        DataHandle& operator=(DataHandle&& other)
-        {
-          decrement_ref_count_();
-          data_ = other.data_;
-          return *this;
-        }
-
-        ~DataHandle()
-        {
-          decrement_ref_count_();
-        }
-
-        Data& operator*() const
-        {
-          assert(data_);
-          return *data_;
-        }
-
-        Data* operator->() const
-        {
-          assert(data_);
-          return data_;
-        }
-
-        Data* leak()
-        {
-          assert(data_);
-          return std::exchange(data_, nullptr);
-        }
-
-      private:
-        void decrement_ref_count_()
-        {
-          if (data_ == nullptr)
-          {
-            return;
-          }
-
-          size_t prev_ref_count = data_->ref_count.fetch_sub(1);
-          // This is the last instance - we need to destroy the continuation
-          if (prev_ref_count == 1)
-          {
-            // Copy coroutine handle into the current frame
-            // (`*data_` is stored in the coroutine it will be destroying)
-            auto continuation = data_->continuation;
-            // The continuation may be null if it was reset or not set at all
-            if (continuation != nullptr)
-            {
-              // Destroy the non finished coroutine
-              continuation.destroy();
-            }
-          }
-        }
-
-        Data* data_;
-      };
-
-      Data data_;
-
-      friend class ServiceClientHandler<ServiceType>;
-    };
-
-  } // namespace internal
 
   // --------------------------------------------------------------
   // |                    ServiceClientHandler                    |
@@ -294,6 +135,18 @@ namespace mrs_lib
 
   //}
 
+  template <class ServiceType>
+  size_t ServiceClientHandler<ServiceType>::prunePendingRequests()
+  {
+    if (!impl_)
+    {
+      RCLCPP_ERROR(rclcpp::get_logger("ServiceClientHandler"), "Not initialized, cannot use prunePendingRequests()!");
+      return false;
+    }
+    return impl_->prunePendingRequests();
+  }
+
+
   // --------------------------------------------------------------
   // |                 ServiceClientHandler::Impl                 |
   // --------------------------------------------------------------
@@ -370,9 +223,78 @@ namespace mrs_lib
       return future;
     }
 
-    internal::ServiceAwaitable<ServiceType> callAwaitable(const std::shared_ptr<typename ServiceType::Request>& request)
+    Task<std::optional<std::shared_ptr<typename ServiceType::Response>>> callAwaitable(const std::shared_ptr<typename ServiceType::Request>& request)
     {
-      return internal::ServiceAwaitable<ServiceType>(service_client_, request);
+      using Response = ServiceType::Response;
+      using Client = rclcpp::Client<ServiceType>;
+      using SharedFutureAndRequestId = Client::SharedFutureAndRequestId;
+      using StopTokenBehavior = coro::internal::LowLevelEventAwaitable::StopTokenBehavior;
+
+      struct StateData
+      {
+        std::mutex mutex{};
+        bool cancelled = false;
+
+        std::optional<SharedFutureAndRequestId> future_and_id{};
+      };
+
+      if (!service_client_->service_is_ready())
+      {
+        co_return std::nullopt;
+      }
+
+      auto [event, awaitable] = coro::make_event();
+
+      std::shared_ptr<StateData> state_data = std::make_shared<StateData>();
+
+      auto register_waker = [&event, client = service_client_, request, state_data]() {
+        std::lock_guard lock(state_data->mutex);
+        if (state_data->cancelled)
+        {
+          event.try_cancel();
+          return;
+        }
+        auto shared_event = std::make_shared<coro::Event>(std::move(event));
+        state_data->future_and_id =
+            client->async_send_request(request, [shared_event](std::shared_future<std::shared_ptr<Response>>) { shared_event->try_trigger(); });
+      };
+
+      auto low_level_awaitable = coro::internal::get_low_level_event_awaitable(std::move(awaitable));
+
+      {
+        // If cancellation is requested via stop token, this callback sets
+        // cancelled flag on the state and removes a the pending request.
+        // The flag is set to stop sending the request in case the stop token
+        // is triggered before the service is called.
+        std::stop_callback remove_request_if_canceled(co_await coro::get_task_stop_token(), [state_data, client_weak = std::weak_ptr(service_client_)]() {
+          std::lock_guard lock(state_data->mutex);
+          state_data->cancelled = true;
+          std::shared_ptr<Client> client = client_weak.lock();
+          if (client == nullptr || !state_data->future_and_id.has_value())
+          {
+            return;
+          }
+          client->remove_pending_request(state_data->future_and_id.value());
+        });
+
+        co_await std::move(low_level_awaitable).get_awaitable(StopTokenBehavior::ignore, register_waker);
+      }
+
+      {
+        std::lock_guard lock(state_data->mutex);
+        if (!state_data->future_and_id.has_value())
+        {
+          co_return std::nullopt;
+        }
+
+        auto future = state_data->future_and_id.value().future;
+        if (future.wait_for(std::chrono::nanoseconds(0)) == std::future_status::timeout)
+        {
+          co_return std::nullopt;
+        }
+
+        co_return std::shared_ptr<Response>(future.get());
+      }
     }
 
     /**
@@ -406,6 +328,16 @@ namespace mrs_lib
     bool isServiceReady() const
     {
       return service_client_->service_is_ready();
+    }
+
+    /**
+     * @brief Clean all pending requests.
+     *
+     * @return number of pending requests that were removed
+     */
+    size_t prunePendingRequests() const
+    {
+      return service_client_->prune_pending_requests();
     }
 
   private:

--- a/include/mrs_lib/service_client_handler.h
+++ b/include/mrs_lib/service_client_handler.h
@@ -15,15 +15,6 @@
 
 namespace mrs_lib
 {
-  template <class ServiceType>
-  class ServiceClientHandler;
-
-  namespace internal
-  {
-    template <typename ServiceType>
-      requires(rosidl_generator_traits::is_service<ServiceType>::value)
-    class [[nodiscard("This service call is only performed when `co_await`ed.")]] ServiceAwaitable;
-  }
 
   /* class ServiceClientHandler //{ */
 
@@ -147,6 +138,18 @@ namespace mrs_lib
      * @return true if the service is available, false otherwise
      */
     bool isServiceReady() const;
+
+    /**
+     * @brief Clean all pending requests.
+     *
+     * @return number of pending requests that were removed
+     *
+     * @warning
+     * Calling this will not wake up threads that are waiting on @ref callSync or future.get.
+     * These threads will be deadlocked, unless woken by some other means.
+     * Coroutines waiting on @ref callAwaitable will be cancelled.
+     */
+    size_t prunePendingRequests();
 
   private:
     class Impl;

--- a/src/coro/event.cpp
+++ b/src/coro/event.cpp
@@ -1,0 +1,246 @@
+#include "mrs_lib/coro/event.hpp"
+
+#include <memory>
+#include <coroutine>
+#include <mutex>
+#include <cassert>
+#include <optional>
+#include <utility>
+
+#include "mrs_lib/coro/internal/continuation.hpp"
+#include "mrs_lib/coro/internal/thread_local_continuation_scheduler.hpp"
+
+
+namespace mrs_lib::coro
+{
+
+  std::pair<Event, EventAwaitable> make_event()
+  {
+    auto state = std::make_shared<internal::EventState>();
+    return {
+        Event(state),
+        EventAwaitable(internal::LowLevelEventAwaitable(state)),
+    };
+  }
+
+  EventError::EventError(Type type) : std::logic_error(get_msg(type)), type_(type)
+  {
+  }
+
+  const char* EventError::get_msg(Type type)
+  {
+    switch (type)
+    {
+    case Type::empty_awaitable_state:
+      return "EventError: This awaitable is empty";
+    }
+    // Not as `default:` to show switch warning if some case is missed.
+    return "EventError: Unknown";
+  }
+
+  namespace internal
+  {
+
+    void EventState::StopCallbackCallable::operator()()
+    {
+      assert(event_state != nullptr);
+      event_state->try_cancel();
+    }
+
+    bool EventState::try_trigger()
+    {
+      std::coroutine_handle<> handle = nullptr;
+
+      {
+        using Status = internal::EventState::Status;
+        std::lock_guard lock(mutex_);
+        if (status_ != Status::unset)
+        {
+          return false;
+        }
+        status_ = Status::set;
+        handle = continuation_.release();
+      }
+
+      if (handle)
+      {
+        internal::resume_coroutine_soon(handle);
+      }
+
+      return true;
+    }
+
+    bool EventState::try_cancel()
+    {
+      internal::CancellableContinuation continuation{};
+
+      {
+        using Status = internal::EventState::Status;
+        std::lock_guard lock(mutex_);
+        if (status_ != Status::unset)
+        {
+          return false;
+        }
+        status_ = Status::cancelled;
+        continuation = std::exchange(continuation_, {});
+      }
+
+      continuation.cancel_and_destroy();
+
+      return true;
+    }
+
+    bool EventState::add_continuation(CancellableContinuation continuation, bool token_cancelable, std::function<void()> callback)
+    {
+      std::unique_lock lock(mutex_);
+
+      switch (status_)
+      {
+      case Status::unset: {
+        // Event not yet triggered. Store the continuation and suspend.
+        assert(continuation_ == nullptr);
+        continuation_ = std::move(continuation);
+        std::stop_token token = continuation_.get_token();
+        lock.unlock();
+        // The callbacks may immediately trigger so we need to unlock the lock before it is created.
+        callback();
+        if (token_cancelable)
+        {
+          // Since no other place interacts with the stop callback, it is safe to set it even when not holding the lock.
+          stop_callback_.emplace(std::move(token), StopCallbackCallable{.event_state = this});
+        }
+        return true;
+      }
+      case Status::set:
+        // Do not suspend, the event was already triggered.
+        continuation.release();
+        return false;
+      case Status::cancelled:
+        // Event cancelled. Unlock the state before destroying the continuation.
+        lock.unlock();
+        continuation.cancel_and_destroy();
+        return true;
+      }
+
+      assert(false);
+    }
+
+    bool EventState::is_ready()
+    {
+      std::lock_guard lock(mutex_);
+      return status_ == Status::set;
+    }
+
+
+    LowLevelEventAwaitable::Awaiter::Awaiter(std::shared_ptr<internal::EventState> state, bool token_cancellable, std::function<void()> callback)
+        : state_(std::move(state)), is_token_cancellable_(token_cancellable), callback_(std::move(callback))
+    {
+    }
+
+    bool LowLevelEventAwaitable::Awaiter::await_ready()
+    {
+      assert(state_ != nullptr);
+      return state_->is_ready();
+    }
+
+    bool LowLevelEventAwaitable::Awaiter::await_suspend(CancellableContinuation continuation)
+    {
+      assert(state_ != nullptr);
+      return state_->add_continuation(std::move(continuation), is_token_cancellable_, std::exchange(callback_, {}));
+    }
+
+    void LowLevelEventAwaitable::Awaiter::await_resume()
+    {
+    }
+
+
+    LowLevelEventAwaitable::LowLevelEventAwaitable(LowLevelEventAwaitable&& other) noexcept : state_(std::exchange(other.state_, nullptr))
+    {
+    }
+
+    LowLevelEventAwaitable& LowLevelEventAwaitable::operator=(LowLevelEventAwaitable&& other) noexcept
+    {
+      state_ = std::exchange(other.state_, nullptr);
+      return *this;
+    }
+
+    auto LowLevelEventAwaitable::get_awaitable() && -> ImmediateAwaitable<Awaiter>
+    {
+      return std::move(*this).get_awaitable(StopTokenBehavior::respect, [] {});
+    }
+
+
+    auto LowLevelEventAwaitable::get_awaitable(StopTokenBehavior stop_token_behavior, std::function<void()> callback) && -> ImmediateAwaitable<Awaiter>
+    {
+      if (state_ == nullptr)
+      {
+        throw EventError(EventError::Type::empty_awaitable_state);
+      }
+
+      bool token_cancellable = stop_token_behavior == StopTokenBehavior::respect;
+      return Awaiter(std::exchange(state_, nullptr), token_cancellable, std::exchange(callback, {}));
+    }
+
+    LowLevelEventAwaitable::LowLevelEventAwaitable(std::shared_ptr<internal::EventState> state) : state_(std::move(state))
+    {
+      assert(state_ != nullptr);
+    }
+
+    LowLevelEventAwaitable get_low_level_event_awaitable(EventAwaitable event_awaitable)
+    {
+      return std::move(event_awaitable).internal_awaitable_;
+    }
+
+  } // namespace internal
+
+  Event::~Event()
+  {
+    try_cancel();
+  }
+
+  Event::Event(Event&& other) noexcept : state_(std::exchange(other.state_, nullptr))
+  {
+  }
+
+  Event& Event::operator=(Event&& other) noexcept
+  {
+    state_ = std::exchange(other.state_, nullptr);
+    return *this;
+  }
+
+  bool Event::try_trigger()
+  {
+    if (state_ == nullptr)
+    {
+      return false;
+    }
+
+    return state_->try_trigger();
+  }
+
+  bool Event::try_cancel()
+  {
+    if (state_ == nullptr)
+    {
+      return false;
+    }
+
+    return state_->try_cancel();
+  }
+
+  Event::Event(std::shared_ptr<internal::EventState> state) : state_(std::move(state))
+  {
+    assert(state_ != nullptr);
+  }
+
+
+  EventAwaitable::EventAwaitable(internal::LowLevelEventAwaitable internal_awaitable) : internal_awaitable_(std::move(internal_awaitable))
+  {
+  }
+
+  auto EventAwaitable::wait() && -> internal::ImmediateAwaitable<internal::LowLevelEventAwaitable::Awaiter>
+  {
+    return std::move(internal_awaitable_).get_awaitable();
+  }
+
+} // namespace mrs_lib::coro

--- a/test/coro/CMakeLists.txt
+++ b/test/coro/CMakeLists.txt
@@ -2,6 +2,7 @@ add_subdirectory(compilation_tests)
 
 mrs_lib_add_simple_labeled_gtest(coro test_coro_cancellation "cancellation_test.cpp")
 mrs_lib_add_simple_labeled_gtest(coro test_coro "coro_test.cpp")
+mrs_lib_add_simple_labeled_gtest(coro test_coro_event "event_test.cpp")
 
 set_tests_properties(test_coro
   PROPERTIES

--- a/test/coro/event_test.cpp
+++ b/test/coro/event_test.cpp
@@ -1,0 +1,232 @@
+#include "mrs_lib/coro/event.hpp"
+
+#include <gtest/gtest.h>
+
+#include "mrs_lib/coro/runners.hpp"
+#include "mrs_lib/coro/task.hpp"
+#include "mrs_lib/utility/scope_cleanup.hpp"
+
+namespace
+{
+  struct DataOut
+  {
+    bool finished = false;
+    bool destroyed = false;
+  };
+
+  mrs_lib::Task<> wait_for_event(mrs_lib::coro::EventAwaitable event_awaitable, DataOut& out)
+  {
+    mrs_lib::ScopeCleanup set_destroyed_clenup([&] { out.destroyed = true; });
+    co_await std::move(event_awaitable).wait();
+    out.finished = true;
+  }
+
+  mrs_lib::Task<> wait_for_event_store_waker(DataOut& out, std::function<void()>& waker)
+  {
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+    using StopTokenBehavior = mrs_lib::coro::internal::LowLevelEventAwaitable::StopTokenBehavior;
+    mrs_lib::ScopeCleanup set_destroyed_clenup([&] { out.destroyed = true; });
+    auto low_level_awaitable = mrs_lib::coro::internal::get_low_level_event_awaitable(std::move(awaitable));
+    co_await std::move(low_level_awaitable).get_awaitable(StopTokenBehavior::respect, [&] {
+      waker = [shared_waker = std::make_shared<mrs_lib::coro::Event>(std::move(event))] { shared_waker->try_trigger(); };
+    });
+    out.finished = true;
+  }
+
+  TEST(MrsLibCoroEvent, EventTriggerAfterSuspend)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    mrs_lib::coro::internal::start_task(wait_for_event, std::move(awaitable), std::ref(data_out));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    ASSERT_TRUE(event.try_trigger());
+
+    EXPECT_TRUE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, EventTriggerBeforeSuspend)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    ASSERT_TRUE(event.try_trigger());
+
+    mrs_lib::coro::internal::start_task(wait_for_event, std::move(awaitable), std::ref(data_out));
+    EXPECT_TRUE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, EventCancelAfterSuspend)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    mrs_lib::coro::internal::start_task(wait_for_event, std::move(awaitable), std::ref(data_out));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    ASSERT_TRUE(event.try_cancel());
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, EventCancelBeforeSuspend)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    ASSERT_TRUE(event.try_cancel());
+
+    mrs_lib::coro::internal::start_task(wait_for_event, std::move(awaitable), std::ref(data_out));
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, EventCancelOnDestroy)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    mrs_lib::coro::internal::start_task(wait_for_event, std::move(awaitable), std::ref(data_out));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    {
+      mrs_lib::coro::Event inner_event = std::move(event);
+      EXPECT_FALSE(data_out.finished);
+      EXPECT_FALSE(data_out.destroyed);
+    }
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, SecondTriggerFails)
+  {
+    using mrs_lib::coro::EventError;
+
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    // First should trigger
+    ASSERT_TRUE(event.try_trigger());
+    // Second should fail
+    EXPECT_FALSE(event.try_cancel());
+  }
+
+  TEST(MrsLibCoroEvent, SecondCancelFails)
+  {
+    using mrs_lib::coro::EventError;
+
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    // First should cancel
+    ASSERT_TRUE(event.try_cancel());
+    // Second should fail
+    EXPECT_FALSE(event.try_cancel());
+  }
+
+  TEST(MrsLibCoroEvent, SecondAwaitThrows)
+  {
+    using mrs_lib::coro::EventError;
+
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+    ASSERT_TRUE(event.try_trigger());
+
+    mrs_lib::coro::internal::start_task(
+        [](mrs_lib::coro::EventAwaitable event_awaitable, DataOut& out) -> mrs_lib::Task<> {
+          mrs_lib::ScopeCleanup set_destroyed_clenup([&] { out.destroyed = true; });
+          // First should succeed
+          EXPECT_NO_THROW(co_await std::move(event_awaitable).wait());
+          // Second should throw
+          EXPECT_THROW(co_await std::move(event_awaitable).wait(), mrs_lib::coro::EventError);
+          out.finished = true;
+        },
+        std::move(awaitable), std::ref(data_out));
+
+    EXPECT_TRUE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, StopTokenCancelAfterSuspend)
+  {
+    DataOut data_out{};
+    auto [event, awaitable] = mrs_lib::coro::make_event();
+
+    std::stop_source stop_source{};
+    mrs_lib::coro::internal::start_task(stop_source.get_token(), wait_for_event, std::move(awaitable), std::ref(data_out));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    stop_source.request_stop();
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, WakerCanResumeImmediately)
+  {
+    DataOut data_out{};
+
+    mrs_lib::coro::internal::start_task([&]() -> mrs_lib::Task<> {
+      auto [event, awaitable] = mrs_lib::coro::make_event();
+      using StopTokenBehavior = mrs_lib::coro::internal::LowLevelEventAwaitable::StopTokenBehavior;
+      mrs_lib::ScopeCleanup set_destroyed_clenup([&] { data_out.destroyed = true; });
+      auto low_level_awaitable = mrs_lib::coro::internal::get_low_level_event_awaitable(std::move(awaitable));
+      co_await std::move(low_level_awaitable)
+          .get_awaitable(StopTokenBehavior::respect,
+                         [shared_event = std::make_shared<mrs_lib::coro::Event>(std::move(event))]() { shared_event->try_trigger(); });
+      data_out.finished = true;
+    });
+
+    EXPECT_TRUE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, WakerCanResumeLater)
+  {
+    DataOut data_out{};
+
+    std::function<void()> waker;
+
+    mrs_lib::coro::internal::start_task(wait_for_event_store_waker, std::ref(data_out), std::ref(waker));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    EXPECT_TRUE(static_cast<bool>(waker));
+    waker();
+
+    EXPECT_TRUE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+  TEST(MrsLibCoroEvent, DroppedWakerCancels)
+  {
+    DataOut data_out{};
+
+    std::function<void()> waker;
+
+    mrs_lib::coro::internal::start_task(wait_for_event_store_waker, std::ref(data_out), std::ref(waker));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_FALSE(data_out.destroyed);
+
+    EXPECT_TRUE(static_cast<bool>(waker));
+    waker = {};
+    EXPECT_FALSE(static_cast<bool>(waker));
+
+    EXPECT_FALSE(data_out.finished);
+    EXPECT_TRUE(data_out.destroyed);
+  }
+
+} // namespace

--- a/test/service_client_handler/test.cpp
+++ b/test/service_client_handler/test.cpp
@@ -4,6 +4,7 @@
 
 #include <mrs_lib/coro/runners.hpp>
 #include <mrs_lib/service_client_handler.h>
+#include <mrs_lib/utility/scope_cleanup.hpp>
 
 #include <std_srvs/srv/set_bool.hpp>
 
@@ -298,6 +299,158 @@ TEST_F(Test, CoroCall)
   executor_->spin();
 
   ASSERT_TRUE(completed);
+}
+
+TEST_F(Test, CoroCallStopTokenCancellation)
+{
+  using RequestType = std_srvs::srv::SetBool::Request;
+  using ResponseType = std_srvs::srv::SetBool::Response;
+
+  // Coroutine based callbacks should handle waiting on single threaded executor
+  initialize<rclcpp::executors::SingleThreadedExecutor>(rclcpp::NodeOptions().use_intra_process_comms(false));
+
+  auto clock = node_->get_clock();
+
+  // | ----------------- create a service server ---------------- |
+
+  const auto callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  const auto service_server = node_->create_service<std_srvs::srv::SetBool>(
+      "/service1", [this](std::shared_ptr<RequestType> req, std::shared_ptr<ResponseType> res) { callbackService(std::move(req), std::move(res)); },
+      rclcpp::ServicesQoS(), callback_group);
+
+  // | ----------------- create a service client ---------------- |
+
+  mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool> client1 = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node_, "service1");
+
+  RCLCPP_INFO(node_->get_logger(), "initialized");
+
+  std::atomic<bool> started = false;
+  std::atomic<bool> completed = false;
+  std::atomic<bool> destroyed = false;
+  rclcpp::TimerBase::SharedPtr tim;
+
+  const auto test_fun = [&]() -> mrs_lib::Task<> {
+    tim->cancel(); // just a one-shot timer
+    started = true;
+    mrs_lib::ScopeCleanup cleanup_set_destroyed([&] { destroyed = true; });
+    mrs_lib::ScopeCleanup cleanup_despin([&] { despin(); });
+
+    auto request = std::make_shared<RequestType>();
+
+    {
+      request->data = true;
+
+      auto opt_response = co_await client1.callAwaitable(request);
+
+      ADD_FAILURE() << "This callback should be cancelled by now.";
+
+      if (!opt_response.has_value())
+      {
+        co_return;
+      }
+
+      auto response = opt_response.value();
+
+      EXPECT_TRUE(response);
+      EXPECT_TRUE(response->success);
+      EXPECT_EQ(response->message, "set");
+    }
+
+    RCLCPP_INFO(node_->get_logger(), "finished");
+
+    completed = true;
+  };
+
+  tim = node_->create_timer(
+      0s,
+      [test_fun, &client1]() -> void {
+        std::stop_source stop_source{};
+        mrs_lib::coro::internal::start_task(stop_source.get_token(), test_fun);
+        stop_source.request_stop();
+        size_t prunned_requests = client1.prunePendingRequests();
+        EXPECT_EQ(prunned_requests, 0) << "Cancelled request should remove itself.";
+      },
+      callback_group);
+  executor_->spin();
+
+  ASSERT_TRUE(started);
+  ASSERT_TRUE(destroyed);
+  ASSERT_FALSE(completed);
+}
+
+TEST_F(Test, CoroCallPruneCancellation)
+{
+  using RequestType = std_srvs::srv::SetBool::Request;
+  using ResponseType = std_srvs::srv::SetBool::Response;
+
+  // Coroutine based callbacks should handle waiting on single threaded executor
+  initialize<rclcpp::executors::SingleThreadedExecutor>(rclcpp::NodeOptions().use_intra_process_comms(false));
+
+  auto clock = node_->get_clock();
+
+  // | ----------------- create a service server ---------------- |
+
+  const auto callback_group = node_->create_callback_group(rclcpp::CallbackGroupType::Reentrant);
+  const auto service_server = node_->create_service<std_srvs::srv::SetBool>(
+      "/service1", [this](std::shared_ptr<RequestType> req, std::shared_ptr<ResponseType> res) { callbackService(std::move(req), std::move(res)); },
+      rclcpp::ServicesQoS(), callback_group);
+
+  // | ----------------- create a service client ---------------- |
+
+  mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool> client1 = mrs_lib::ServiceClientHandler<std_srvs::srv::SetBool>(node_, "service1");
+
+  RCLCPP_INFO(node_->get_logger(), "initialized");
+
+  std::atomic<bool> started = false;
+  std::atomic<bool> completed = false;
+  std::atomic<bool> destroyed = false;
+  rclcpp::TimerBase::SharedPtr tim;
+
+  const auto test_fun = [&]() -> mrs_lib::Task<> {
+    tim->cancel(); // just a one-shot timer
+    started = true;
+    mrs_lib::ScopeCleanup cleanup_set_destroyed([&] { destroyed = true; });
+    mrs_lib::ScopeCleanup cleanup_despin([&] { despin(); });
+
+    auto request = std::make_shared<RequestType>();
+
+    {
+      request->data = true;
+
+      auto opt_response = co_await client1.callAwaitable(request);
+
+      ADD_FAILURE() << "This callback should be cancelled by now.";
+
+      if (!opt_response.has_value())
+      {
+        co_return;
+      }
+
+      auto response = opt_response.value();
+
+      EXPECT_TRUE(response);
+      EXPECT_TRUE(response->success);
+      EXPECT_EQ(response->message, "set");
+    }
+
+    RCLCPP_INFO(node_->get_logger(), "finished");
+
+    completed = true;
+  };
+
+  tim = node_->create_timer(
+      0s,
+      [test_fun, &client1]() -> void {
+        mrs_lib::coro::internal::start_task(test_fun);
+        size_t prunned_requests = client1.prunePendingRequests();
+        EXPECT_EQ(prunned_requests, 1) << "The callback should be pruned by this call.";
+      },
+      callback_group);
+  executor_->spin();
+
+  ASSERT_TRUE(started);
+  ASSERT_TRUE(destroyed);
+  ASSERT_FALSE(completed);
 }
 
 /* TEST_F(Test, test_bad_address) //{ */


### PR DESCRIPTION
### Summary
- Add coro Event - oneshot awaitable communication channel with cancellation support.
- Update `ServiceClientHandler::Impl::callAwaitable` to use the added Event.
  - This also adds support for service await cancellation.
- Add `ServiceClientHandler::prunePendingRequests` - exposes the `prune_pending_requests` method of the rclcpp client.